### PR TITLE
Adding ability to sort and request single page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
   </dependencyManagement>
 
   <dependencies>
+	<dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>2.14.0</version>
+        <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/src/main/java/org/zendesk/client/v2/model/CustomFieldValue.java
+++ b/src/main/java/org/zendesk/client/v2/model/CustomFieldValue.java
@@ -52,4 +52,32 @@ public class CustomFieldValue implements Serializable {
                 ", value=" + Arrays.toString(value) +
                 '}';
     }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + Arrays.hashCode(value);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CustomFieldValue other = (CustomFieldValue) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (!Arrays.equals(value, other.value))
+			return false;
+		return true;
+	}
 }

--- a/src/main/java/org/zendesk/client/v2/model/SearchResultPage.java
+++ b/src/main/java/org/zendesk/client/v2/model/SearchResultPage.java
@@ -1,0 +1,138 @@
+package org.zendesk.client.v2.model;
+
+import java.util.LinkedList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The Class SearchResultPage represents the entities returned as a result of
+ * the pageable request (list, search).
+ *
+ * @param <T>
+ *            the SearchResultEntity type
+ */
+public class SearchResultPage<T extends SearchResultEntity> {
+
+	/** The results. */
+	private LinkedList<T> results;
+
+	/** The next page. */
+	@JsonProperty("next_page")
+	private String nextPage;
+
+	/** The prev page. */
+	@JsonProperty("prev_page")
+	private String prevPage;
+
+	/** The count. */
+	private int count;
+
+	/**
+	 * Instantiates a new SearchResultPage containing current page results/entities,
+	 * count of all elements as well as links to the previous and next page
+	 *
+	 * @param results
+	 *            the results
+	 * @param nextPage
+	 *            the next page url
+	 * @param prevPage
+	 *            the prev page url
+	 * @param count
+	 *            the count of all the elements to be returned
+	 */
+	public SearchResultPage(LinkedList<T> results, String nextPage, String prevPage, int count) {
+		super();
+		this.results = results;
+		this.nextPage = nextPage;
+		this.prevPage = prevPage;
+		this.count = count;
+	}
+
+	/**
+	 * Instantiates a new SearchResultPage when there are no results to be returned
+	 */
+	public SearchResultPage() {
+		super();
+		this.results = new LinkedList<T>();
+		this.nextPage = "";
+		this.prevPage = "";
+		this.count = 0;
+	}
+
+	/**
+	 * Gets the results.
+	 *
+	 * @return the results
+	 */
+	public LinkedList<T> getResults() {
+		return results;
+	}
+
+	/**
+	 * Sets the results.
+	 *
+	 * @param results
+	 *            the new results
+	 */
+	public void setResults(LinkedList<T> results) {
+		this.results = results;
+	}
+
+	/**
+	 * Gets the next page.
+	 *
+	 * @return the next page
+	 */
+	public String getNextPage() {
+		return nextPage;
+	}
+
+	/**
+	 * Sets the next page.
+	 *
+	 * @param nextPage
+	 *            the new next page
+	 */
+	public void setNextPage(String nextPage) {
+		this.nextPage = nextPage;
+	}
+
+	/**
+	 * Gets the prev page.
+	 *
+	 * @return the prev page
+	 */
+	public String getPrevPage() {
+		return prevPage;
+	}
+
+	/**
+	 * Sets the prev page.
+	 *
+	 * @param prevPage
+	 *            the new prev page
+	 */
+	public void setPrevPage(String prevPage) {
+		this.prevPage = prevPage;
+	}
+
+	/**
+	 * Gets the count.
+	 *
+	 * @return the count
+	 */
+	public int getCount() {
+		return count;
+	}
+
+	/**
+	 * Sets the count.
+	 *
+	 * @param count
+	 *            the new count
+	 */
+	public void setCount(int count) {
+		this.count = count;
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/SearchResultPage.java
+++ b/src/main/java/org/zendesk/client/v2/model/SearchResultPage.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @param <T>
  *            the SearchResultEntity type
+ *            
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class SearchResultPage<T extends SearchResultEntity> {
 

--- a/src/main/java/org/zendesk/client/v2/model/request/page/IPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/IPageableRequest.java
@@ -1,0 +1,66 @@
+package org.zendesk.client.v2.model.request.page;
+
+import java.util.Map;
+
+import org.zendesk.client.v2.model.sort.Sort;
+
+// TODO: Auto-generated Javadoc
+/**
+ * The Interface IPageableRequest represents the request to return entities that
+ * should be displayed on the specific page with per page number of elements.
+ * Sort properties can be set as well.
+ */
+public interface IPageableRequest {
+
+	/**
+	 * Gets the page to be returned.
+	 *
+	 * @return the page
+	 */
+	public int getPage();
+
+	/**
+	 * Sets the page to be returned.
+	 *
+	 * @param page
+	 *            the new page
+	 */
+	public void setPage(int page);
+
+	/**
+	 * Gets the number of elements per page.
+	 *
+	 * @return the per page
+	 */
+	public int getPerPage();
+
+	/**
+	 * Sets the number of elements per page.
+	 *
+	 * @param perPage
+	 *            the new per page
+	 */
+	public void setPerPage(int perPage);
+
+	/**
+	 * Gets the sort properties.
+	 *
+	 * @return the sort
+	 */
+	public Sort getSort();
+
+	/**
+	 * Sets the sort properties.
+	 *
+	 * @param sort
+	 *            the new sort
+	 */
+	public void setSort(Sort sort);
+
+	/**
+	 * Returns the map of query parameters and values
+	 *
+	 * @return the query parameters
+	 */
+	public Map<String, Object> getQueryParameters();
+}

--- a/src/main/java/org/zendesk/client/v2/model/request/page/IPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/IPageableRequest.java
@@ -3,12 +3,13 @@ package org.zendesk.client.v2.model.request.page;
 import java.util.Map;
 
 import org.zendesk.client.v2.model.sort.Sort;
-
-// TODO: Auto-generated Javadoc
 /**
  * The Interface IPageableRequest represents the request to return entities that
  * should be displayed on the specific page with per page number of elements.
  * Sort properties can be set as well.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public interface IPageableRequest {
 

--- a/src/main/java/org/zendesk/client/v2/model/request/page/PageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/PageableRequest.java
@@ -7,6 +7,9 @@ import org.zendesk.client.v2.model.sort.Sort;
 
 /**
  * The Class PageableRequest.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public abstract class PageableRequest implements IPageableRequest {
 

--- a/src/main/java/org/zendesk/client/v2/model/request/page/PageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/PageableRequest.java
@@ -1,0 +1,146 @@
+package org.zendesk.client.v2.model.request.page;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zendesk.client.v2.model.sort.Sort;
+
+/**
+ * The Class PageableRequest.
+ */
+public abstract class PageableRequest implements IPageableRequest {
+
+	/** The Constant PAGE. */
+	public static final String PAGE = "page";
+	
+	/** The Constant PER_PAGE. */
+	public static final String PER_PAGE = "per_page";
+	
+	/** The page. */
+	private int page;
+
+	/** The per page. */
+	private int perPage;
+
+	/** The sort. */
+	private Sort sort;
+
+	/**
+	 * Instantiates a new PageableRequest with sort properites. Page and perPage
+	 * properties to be set to the defaults on the requested endpoint.
+	 *
+	 * @param sort
+	 *            the sort
+	 */
+	public PageableRequest(Sort sort) {
+		this(0, 0, sort);
+	}
+
+	/**
+	 * Instantiates a new PageableRequest.
+	 *
+	 * @param page
+	 *            the page
+	 * @param perPage
+	 *            the per page
+	 * @param sort
+	 *            the sort
+	 */
+	public PageableRequest(int page, int perPage, Sort sort) {
+		super();
+		if(page < 0) {
+			throw new IllegalArgumentException("Page cannot be less than 0");
+		}
+		if(perPage < 0) {
+			throw new IllegalArgumentException("Per Page cannot be less than 1");
+		}
+		this.page = page;
+		this.perPage = perPage;
+		this.sort = sort;
+	}
+
+	/**
+	 * Instantiates a new PageableRequest without sorting properties.
+	 *
+	 * @param page            the page
+	 * @param perPage the per page
+	 */
+	public PageableRequest(int page, int perPage) {
+		this(page, perPage, null);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.IPageableRequest#getPage()
+	 */
+	public int getPage() {
+		return page;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.IPageableRequest#setPage(int)
+	 */
+	public void setPage(int page) {
+		this.page = page;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.IPageableRequest#getPerPage()
+	 */
+	public int getPerPage() {
+		return perPage;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.IPageableRequest#setPerPage(int)
+	 */
+	public void setPerPage(int perPage) {
+		this.perPage = perPage;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.IPageableRequest#getSort()
+	 */
+	public Sort getSort() {
+		return sort;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.zendesk.client.v2.model.IPageableRequest#setSort(org.zendesk.client.v2.
+	 * model.sort.Sort)
+	 */
+	public void setSort(Sort sort) {
+		this.sort = sort;
+	}
+
+	
+	/* (non-Javadoc)
+	 * @see org.zendesk.client.v2.model.request.page.IPageableRequest#getQueryParameters()
+	 */
+	@Override
+	public Map<String, Object> getQueryParameters() {
+		Map<String, Object> params = new HashMap<String, Object>();
+		if (page > 1) {
+			params.put(PAGE, page);
+		}
+		if(perPage > 0) {
+			params.put(PER_PAGE, perPage);
+		}
+		if(sort != null) {
+			params.putAll(sort.getQueryParameters());
+		}
+		return params;
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/request/page/SearchPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/SearchPageableRequest.java
@@ -1,0 +1,34 @@
+package org.zendesk.client.v2.model.request.page;
+
+import org.zendesk.client.v2.model.sort.search.SearchSort;
+
+/**
+ * The Class specifies the PageableRequest for Search REST endpoint.
+ */
+public class SearchPageableRequest extends PageableRequest {
+
+	/**
+	 * Instantiates a new SearchPageableRequest with sort properties
+	 *
+	 * @param sort
+	 *            the sort
+	 */
+	public SearchPageableRequest(SearchSort sort) {
+		super(sort);
+	}
+
+	/**
+	 * Instantiates a new SearchPageableRequest
+	 *
+	 * @param page
+	 *            the page
+	 * @param perPage
+	 *            the per page
+	 * @param sort
+	 *            the sort
+	 */
+	public SearchPageableRequest(int page, int perPage, SearchSort sort) {
+		super(page, perPage, sort);
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/request/page/SearchPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/SearchPageableRequest.java
@@ -4,6 +4,9 @@ import org.zendesk.client.v2.model.sort.search.SearchSort;
 
 /**
  * The Class specifies the PageableRequest for Search REST endpoint.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class SearchPageableRequest extends PageableRequest {
 

--- a/src/main/java/org/zendesk/client/v2/model/request/page/TicketPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/TicketPageableRequest.java
@@ -1,0 +1,34 @@
+package org.zendesk.client.v2.model.request.page;
+
+import org.zendesk.client.v2.model.sort.ticket.TicketSort;
+
+/**
+ * The Class specifies the PageableRequest for Search REST endpoint.
+ */
+public class TicketPageableRequest extends PageableRequest {
+
+	/**
+	 * Instantiates a new TicketPageableRequest
+	 *
+	 * @param sort
+	 *            the sort
+	 */
+	public TicketPageableRequest(TicketSort sort) {
+		super(sort);
+	}
+
+	/**
+	 * Instantiates a new TicketPageableRequest
+	 *
+	 * @param page
+	 *            the page
+	 * @param perPage
+	 *            the per page
+	 * @param sort
+	 *            the sort
+	 */
+	public TicketPageableRequest(int page, int perPage, TicketSort sort) {
+		super(page, perPage, sort);
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/request/page/TicketPageableRequest.java
+++ b/src/main/java/org/zendesk/client/v2/model/request/page/TicketPageableRequest.java
@@ -4,6 +4,9 @@ import org.zendesk.client.v2.model.sort.ticket.TicketSort;
 
 /**
  * The Class specifies the PageableRequest for Search REST endpoint.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class TicketPageableRequest extends PageableRequest {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/FieldSearch.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/FieldSearch.java
@@ -1,10 +1,12 @@
 package org.zendesk.client.v2.model.search;
 
-// TODO: Auto-generated Javadoc
 /**
  * The Class FieldSearch represents the property that should have specific value
  * in the searched entity. It also enables the ability to specify id entity
  * should not have specified property.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class FieldSearch {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/FieldSearch.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/FieldSearch.java
@@ -1,0 +1,156 @@
+package org.zendesk.client.v2.model.search;
+
+// TODO: Auto-generated Javadoc
+/**
+ * The Class FieldSearch represents the property that should have specific value
+ * in the searched entity. It also enables the ability to specify id entity
+ * should not have specified property.
+ */
+public class FieldSearch {
+
+	/** The exclude. */
+	private boolean exclude = false;
+
+	/** The property. */
+	private SearchableProperty property;
+
+	/** The op. */
+	private SearchOp op;
+
+	/** The value. */
+	private Object value;
+
+	/**
+	 * Instantiates a FieldSearch for a specific property, with specific operation
+	 * and value.
+	 *
+	 * @param property
+	 *            the property
+	 * @param op
+	 *            the op
+	 * @param value
+	 *            the value
+	 */
+	public FieldSearch(SearchableProperty property, SearchOp op, Object value) {
+		this(false, property, op, value);
+	}
+
+	/**
+	 * Instantiates a FieldSearch for a specific property, with specific operation
+	 * and value. Setting the exclude parameter to false will look for entities
+	 * where property does not contain property with matching value.
+	 *
+	 * @param exclude
+	 *            the exclude
+	 * @param property
+	 *            the property
+	 * @param op
+	 *            the op
+	 * @param value
+	 *            the value
+	 */
+	public FieldSearch(boolean exclude, SearchableProperty property, SearchOp op, Object value) {
+		if(property == null) {
+			throw new IllegalArgumentException("Property can not be null.");
+		}
+		if(op == null) {
+			throw new IllegalArgumentException("Search operation can not be null.");
+		}
+		this.exclude = exclude;
+		this.property = property;
+		this.op = op;
+		this.value = value;
+	}
+
+	/**
+	 * Checks if is exclude.
+	 *
+	 * @return true, if is exclude
+	 */
+	public boolean isExclude() {
+		return exclude;
+	}
+
+	/**
+	 * Sets the exclude.
+	 *
+	 * @param exclude
+	 *            the new exclude
+	 */
+	public void setExclude(boolean exclude) {
+		this.exclude = exclude;
+	}
+
+	/**
+	 * Gets the property.
+	 *
+	 * @return the property
+	 */
+	public SearchableProperty getProperty() {
+		return property;
+	}
+
+	/**
+	 * Sets the property.
+	 *
+	 * @param property
+	 *            the new property
+	 */
+	public void setProperty(SearchableProperty property) {
+		this.property = property;
+	}
+
+	/**
+	 * Gets the op.
+	 *
+	 * @return the op
+	 */
+	public SearchOp getOp() {
+		return op;
+	}
+
+	/**
+	 * Sets the op.
+	 *
+	 * @param op
+	 *            the new op
+	 */
+	public void setOp(SearchOp op) {
+		this.op = op;
+	}
+
+	/**
+	 * Gets the value.
+	 *
+	 * @return the value
+	 */
+	public Object getValue() {
+		return value;
+	}
+
+	/**
+	 * Sets the value.
+	 *
+	 * @param value
+	 *            the new value
+	 */
+	public void setValue(Object value) {
+		this.value = value;
+	}
+	
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	public String toString() {
+		StringBuffer sb = new StringBuffer();
+		if(exclude) {
+			sb.append("-");
+		}
+		if("".equals(property.getKeyword())){
+			// In case of ID there is no keyword
+			return sb.append(value).toString();
+		}
+		return sb.append(property.getKeyword()).append(op.getOp()).append(value.toString()).toString();
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/QueryBuilder.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/QueryBuilder.java
@@ -1,0 +1,85 @@
+package org.zendesk.client.v2.model.search;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Class QueryBuilder allows to easily create queries to search for entities
+ * with matching properties.
+ */
+public class QueryBuilder {
+
+	/** The field search. */
+	private List<FieldSearch> fieldSearch;
+
+	/** The phrase search. */
+	private List<String> phraseSearch;
+	
+	/** The result type. */
+	private SearchResultType resultType;
+
+	/**
+	 * Instantiates a new query builder.
+	 */
+	public QueryBuilder() {
+		this.fieldSearch = new ArrayList<FieldSearch>();
+		this.phraseSearch = new ArrayList<String>();
+	}
+
+	/**
+	 * Adds the field search.
+	 *
+	 * @param fieldSearch
+	 *            the field search
+	 * @return the query builder
+	 */
+	public QueryBuilder addFieldSearch(FieldSearch fieldSearch) {
+		this.fieldSearch.add(fieldSearch);
+		return this;
+	}
+
+	/**
+	 * Adds the phrase search.
+	 *
+	 * @param phrase
+	 *            the phrase
+	 * @return the query builder
+	 */
+	public QueryBuilder addPhraseSearch(String phrase) {
+		this.phraseSearch.add(phrase);
+		return this;
+	}
+	
+	public QueryBuilder setResultType(SearchResultType resultType) {
+		this.resultType = resultType;
+		return this;
+	}
+
+	/**
+	 * Builds the.
+	 *
+	 * @return the string
+	 */
+	public String build() {
+		StringBuffer sb = new StringBuffer();
+		for (FieldSearch field : fieldSearch) {
+			if (sb.length() > 0) {
+				sb.append(" ");
+			}
+			sb.append(field.toString());
+		}
+		for (String phrase : phraseSearch) {
+			if (sb.length() > 0) {
+				sb.append(" ");
+			}
+			sb.append("\"").append(phrase).append("\"");
+		}
+		if(resultType != null) {
+			if(sb.length() > 0) {
+				sb.append(" ");
+			}
+			sb.append("type:").append(resultType.getName());
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/QueryBuilder.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/QueryBuilder.java
@@ -6,6 +6,9 @@ import java.util.List;
 /**
  * The Class QueryBuilder allows to easily create queries to search for entities
  * with matching properties.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class QueryBuilder {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchOp.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchOp.java
@@ -1,0 +1,70 @@
+package org.zendesk.client.v2.model.search;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enumeration contains allowed operations to be used during building of the
+ * query against entity fields.
+ */
+public enum SearchOp {
+
+	/** The equals. */
+	EQUALS(":"),
+
+	/** The less than. */
+	LESS_THAN("<"),
+
+	/** The greater than. */
+	GREATER_THAN(">"),
+
+	/** The less than or equal. */
+	LESS_THAN_OR_EQUAL("<="),
+
+	/** The greater than or equal. */
+	GREATER_THAN_OR_EQUAL(">=");
+
+	/** The op. */
+	private String op;
+
+	/**
+	 * Instantiates a new search op.
+	 *
+	 * @param op
+	 *            the op
+	 */
+	private SearchOp(String op) {
+		this.op = op;
+	}
+
+	/**
+	 * Gets the op.
+	 *
+	 * @return the op
+	 */
+	@JsonValue
+	public String getOp() {
+		return op;
+	}
+
+	/**
+	 * Gets the by op.
+	 *
+	 * @param op
+	 *            the op
+	 * @return the by op
+	 */
+	@JsonCreator
+	public static SearchOp getByOp(String op) {
+		SearchOp searchOp = null;
+		if(op != null) {
+			for (SearchOp searchOpEnum : SearchOp.values()) {
+				if (searchOpEnum.getOp().equalsIgnoreCase(op.trim())) {
+					searchOp = searchOpEnum;
+				}
+			}
+		}
+		return searchOp;
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchOp.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchOp.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Enumeration contains allowed operations to be used during building of the
  * query against entity fields.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum SearchOp {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
@@ -1,0 +1,71 @@
+package org.zendesk.client.v2.model.search;
+
+import org.zendesk.client.v2.model.Group;
+import org.zendesk.client.v2.model.Organization;
+import org.zendesk.client.v2.model.SearchResultEntity;
+import org.zendesk.client.v2.model.Ticket;
+import org.zendesk.client.v2.model.Topic;
+import org.zendesk.client.v2.model.User;
+import org.zendesk.client.v2.model.hc.Article;
+
+/**
+ * Enumeration of the types supported to be returned as a result of the search
+ * query.
+ */
+public enum SearchResultType {
+
+	/** The ticket. */
+	TICKET("ticket", Ticket.class),
+
+	/** The user. */
+	USER("user", User.class),
+
+	/** The group. */
+	GROUP("group", Group.class),
+
+	/** The organization. */
+	ORGANIZATION("organization", Organization.class),
+
+	/** The topic. */
+	TOPIC("topic", Topic.class),
+
+	/** The article. */
+	ARTICLE("article", Article.class);
+
+	/** The name. */
+	private String name;
+
+	/** The clazz. */
+	private Class<? extends SearchResultEntity> clazz;
+
+	/**
+	 * Instantiates a new search result type.
+	 *
+	 * @param name
+	 *            the name
+	 * @param clazz
+	 *            the clazz
+	 */
+	private SearchResultType(String name, Class<? extends SearchResultEntity> clazz) {
+		this.name = name;
+		this.clazz = clazz;
+	}
+
+	/**
+	 * Gets the name.
+	 *
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Gets the type class.
+	 *
+	 * @return the type class
+	 */
+	public Class<? extends SearchResultEntity> getTypeClass() {
+		return clazz;
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
@@ -4,9 +4,7 @@ import org.zendesk.client.v2.model.Group;
 import org.zendesk.client.v2.model.Organization;
 import org.zendesk.client.v2.model.SearchResultEntity;
 import org.zendesk.client.v2.model.Ticket;
-import org.zendesk.client.v2.model.Topic;
 import org.zendesk.client.v2.model.User;
-import org.zendesk.client.v2.model.hc.Article;
 
 /**
  * Enumeration of the types supported to be returned as a result of the search
@@ -27,14 +25,8 @@ public enum SearchResultType {
 	GROUP("group", Group.class),
 
 	/** The organization. */
-	ORGANIZATION("organization", Organization.class),
-
-	/** The topic. */
-	TOPIC("topic", Topic.class),
-
-	/** The article. */
-	ARTICLE("article", Article.class);
-
+	ORGANIZATION("organization", Organization.class);
+	
 	/** The name. */
 	private String name;
 

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchResultType.java
@@ -11,6 +11,9 @@ import org.zendesk.client.v2.model.hc.Article;
 /**
  * Enumeration of the types supported to be returned as a result of the search
  * query.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum SearchResultType {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchableProperty.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchableProperty.java
@@ -2,6 +2,9 @@ package org.zendesk.client.v2.model.search;
 
 /**
  * The Interface SearchableProperty.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public interface SearchableProperty {
 

--- a/src/main/java/org/zendesk/client/v2/model/search/SearchableProperty.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/SearchableProperty.java
@@ -1,0 +1,14 @@
+package org.zendesk.client.v2.model.search;
+
+/**
+ * The Interface SearchableProperty.
+ */
+public interface SearchableProperty {
+
+	/**
+	 * Returns the keyword to be used during building of the search query
+	 *
+	 * @return the keyword representing the entity field
+	 */
+	public String getKeyword();
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/ticket/TicketSearchableProperty.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/ticket/TicketSearchableProperty.java
@@ -1,0 +1,119 @@
+package org.zendesk.client.v2.model.search.ticket;
+
+import org.zendesk.client.v2.model.search.SearchableProperty;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The Enum TicketSearchableProperty contains the Ticket fields with matching
+ * keywords that are enabled for searching/quering
+ */
+public enum TicketSearchableProperty implements SearchableProperty {
+
+	/** The id. */
+	ID(""),
+
+	/** The created. */
+	CREATED("created"),
+
+	/** The updated. */
+	UPDATED("updated"),
+
+	/** The solved. */
+	SOLVED("solved"),
+
+	/** The due date. */
+	DUE_DATE("due_date"),
+
+	/** The assignee. */
+	ASSIGNEE("assignee"),
+
+	/** The submitter. */
+	SUBMITTER("submitter"),
+
+	/** The requester. */
+	REQUESTER("requester"),
+
+	/** The subject. */
+	SUBJECT("subject"),
+
+	/** The description. */
+	DESCRIPTION("description"),
+
+	/** The status. */
+	STATUS("status"),
+
+	/** The ticket type. */
+	TICKET_TYPE("ticket_type"),
+
+	/** The priority. */
+	PRIORITY("priority"),
+
+	/** The group. */
+	GROUP("group"),
+
+	/** The organization. */
+	ORGANIZATION("organization"),
+
+	/** The tags. */
+	TAGS("tags"),
+
+	/** The via. */
+	VIA("via"),
+
+	/** The commenter. */
+	COMMENTER("commenter"),
+
+	/** The cc. */
+	CC("cc"),
+
+	/** The custom field. */
+	CUSTOM_FIELD("fieldvalue"),
+
+	/** The brand. */
+	BRAND("brand");
+
+	/** The keyword. */
+	private String keyword;
+
+	/**
+	 * Instantiates a new TicketSearchableProperty
+	 *
+	 * @param keyword
+	 *            the keyword
+	 */
+	private TicketSearchableProperty(String keyword) {
+		this.keyword = keyword;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.search.SearchableProperty#getKeyword()
+	 */
+	@JsonValue
+	public String getKeyword() {
+		return keyword;
+	}
+
+	/**
+	 * Returns the {@link TicketSearchableProperty} by keyword
+	 *
+	 * @param keyword
+	 *            the keyword
+	 * @return the {@link TicketSearchableProperty}
+	 */
+	@JsonCreator
+	public static TicketSearchableProperty getByKeyword(String keyword) {
+		TicketSearchableProperty searchableProp = null;
+		if (keyword != null) {
+			for (TicketSearchableProperty fieldEnum : TicketSearchableProperty.values()) {
+				if (fieldEnum.getKeyword().equalsIgnoreCase(keyword.trim())) {
+					searchableProp = fieldEnum;
+				}
+			}
+		}
+		return searchableProp;
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/search/ticket/TicketSearchableProperty.java
+++ b/src/main/java/org/zendesk/client/v2/model/search/ticket/TicketSearchableProperty.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * The Enum TicketSearchableProperty contains the Ticket fields with matching
  * keywords that are enabled for searching/quering
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum TicketSearchableProperty implements SearchableProperty {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/Sort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/Sort.java
@@ -1,0 +1,107 @@
+package org.zendesk.client.v2.model.sort;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// TODO: Auto-generated Javadoc
+/**
+ * 
+ * The Class Sort represents the field based on which returned list of entities
+ * should be sorted by and order in which entities should be sorted.
+ * 
+ * @author Tomasz Kurzawa (tzkurzawa@gmail.com)
+ *
+ */
+public class Sort {
+
+	/** The sort by. */
+	public static final String SORT_BY = "sort_by";
+
+	/** The sort order. */
+	public static final String SORT_ORDER = "sort_order";
+
+	/** The field. */
+	private SortableField field;
+
+	/** The order. */
+	private SortOrder order;
+
+	/**
+	 * Instantiates a new sort.
+	 *
+	 * @param field
+	 *            the field
+	 * @param order
+	 *            the order
+	 */
+	public Sort(SortableField field, SortOrder order) {
+		if (field == null) {
+			throw new IllegalArgumentException("Field cannot be null.");
+		}
+		if (order == null) {
+			throw new IllegalArgumentException("Order can not be null.");
+		}
+		this.field = field;
+		this.order = order;
+	}
+
+	/**
+	 * Gets the field.
+	 *
+	 * @return the field
+	 */
+	public SortableField getField() {
+		return field;
+	}
+
+	/**
+	 * Sets the field.
+	 *
+	 * @param field
+	 *            the new field
+	 */
+	public void setField(SortableField field) {
+		this.field = field;
+	}
+
+	/**
+	 * Gets the order.
+	 *
+	 * @return the order
+	 */
+	public SortOrder getOrder() {
+		return order;
+	}
+
+	/**
+	 * Sets the order.
+	 *
+	 * @param order
+	 *            the new order
+	 */
+	public void setOrder(SortOrder order) {
+		this.order = order;
+	}
+
+	/**
+	 * Returns map with name of the sort query parameters and values
+	 *
+	 * @return the query parameters
+	 */
+	public Map<String, Object> getQueryParameters() {
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put(SORT_BY, field.getKeyword());
+		parameters.put(SORT_ORDER, order.getOrder());
+		return parameters;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "Sort [field=" + field + ", order=" + order + "]";
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/Sort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/Sort.java
@@ -3,14 +3,13 @@ package org.zendesk.client.v2.model.sort;
 import java.util.HashMap;
 import java.util.Map;
 
-// TODO: Auto-generated Javadoc
 /**
  * 
  * The Class Sort represents the field based on which returned list of entities
  * should be sorted by and order in which entities should be sorted.
  * 
- * @author Tomasz Kurzawa (tzkurzawa@gmail.com)
- *
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class Sort {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/SortOrder.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/SortOrder.java
@@ -1,0 +1,56 @@
+package org.zendesk.client.v2.model.sort;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The Enumeration for sort order.
+ */
+public enum SortOrder {
+
+	/** The asc. */
+	ASC("asc"),
+	/** The desc. */
+	DESC("desc");
+
+	/** The order. */
+	private String order;
+
+	/**
+	 * Instantiates a new SortOrder.
+	 *
+	 * @param order
+	 *            the order
+	 */
+	private SortOrder(String order) {
+		this.order = order;
+	}
+
+	/**
+	 * Gets the order.
+	 *
+	 * @return the order
+	 */
+	@JsonValue
+	public String getOrder() {
+		return order;
+	}
+
+	/**
+	 * Gets the SortOrder by order.
+	 *
+	 * @param order
+	 *            the order
+	 * @return the by order
+	 */
+	@JsonCreator
+	public static SortOrder getByOrder(String order) {
+		SortOrder sortOrder = null;
+		for (SortOrder sortOrderEnum : SortOrder.values()) {
+			if (sortOrderEnum.getOrder().equalsIgnoreCase(order)) {
+				sortOrder = sortOrderEnum;
+			}
+		}
+		return sortOrder;
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/SortOrder.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/SortOrder.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * The Enumeration for sort order.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum SortOrder {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/SortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/SortableField.java
@@ -1,0 +1,16 @@
+package org.zendesk.client.v2.model.sort;
+
+/**
+ * Enums that contain fields that were enabled for sorting for a given type
+ * should implement this interface.
+ */
+public interface SortableField {
+
+	/**
+	 * Returns the keyword to be used as the 'order_by' value, when sorting results
+	 * based on the field
+	 *
+	 * @return the keyword
+	 */
+	public String getKeyword();
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/SortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/SortableField.java
@@ -3,6 +3,9 @@ package org.zendesk.client.v2.model.sort;
 /**
  * Enums that contain fields that were enabled for sorting for a given type
  * should implement this interface.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public interface SortableField {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSort.java
@@ -1,0 +1,23 @@
+package org.zendesk.client.v2.model.sort.search;
+
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+
+/**
+ * The Class SearchSort represents the sort properties to be associated with the
+ * search request.
+ */
+public class SearchSort extends Sort {
+
+	/**
+	 * Instantiates a new SearchSort.
+	 *
+	 * @param field
+	 *            the field
+	 * @param order
+	 *            the order
+	 */
+	public SearchSort(SearchSortableField field, SortOrder order) {
+		super(field, order);
+	}
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSort.java
@@ -6,6 +6,9 @@ import org.zendesk.client.v2.model.sort.SortOrder;
 /**
  * The Class SearchSort represents the sort properties to be associated with the
  * search request.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class SearchSort extends Sort {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSortableField.java
@@ -1,0 +1,69 @@
+package org.zendesk.client.v2.model.sort.search;
+
+import org.zendesk.client.v2.model.sort.SortableField;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enumeration for search request sortable fields.
+ */
+public enum SearchSortableField implements SortableField {
+
+	/** The updated at. */
+	UPDATED_AT("updated_at"),
+
+	/** The created at. */
+	CREATED_AT("created_at"),
+
+	/** The priority. */
+	PRIORITY("priority"),
+
+	/** The status. */
+	STATUS("status"),
+
+	/** The ticket type. */
+	TICKET_TYPE("ticket_type");
+
+	/** The keyword. */
+	private String keyword;
+
+	/**
+	 * Instantiates a new search sortable field.
+	 *
+	 * @param keyword
+	 *            the keyword
+	 */
+	private SearchSortableField(String keyword) {
+		this.keyword = keyword;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.sort.SortableField#getKeyword()
+	 */
+	@JsonValue
+	public String getKeyword() {
+		return keyword;
+	}
+
+	/**
+	 * Gets the SearchSortableField by keyword.
+	 *
+	 * @param keyword
+	 *            the keyword
+	 * @return the by keyword
+	 */
+	@JsonCreator
+	public static SearchSortableField getByKeyword(String keyword) {
+		SearchSortableField searchField = null;
+		for (SearchSortableField searchFieldEnum : SearchSortableField.values()) {
+			if (searchFieldEnum.getKeyword().equalsIgnoreCase(keyword)) {
+				searchField = searchFieldEnum;
+			}
+		}
+		return searchField;
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/search/SearchSortableField.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Enumeration for search request sortable fields.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum SearchSortableField implements SortableField {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSort.java
@@ -6,6 +6,9 @@ import org.zendesk.client.v2.model.sort.SortOrder;
 /**
  * The Class TicketSort represents the sort properties to be associated with the
  * list ticket request.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public class TicketSort extends Sort {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSort.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSort.java
@@ -1,0 +1,24 @@
+package org.zendesk.client.v2.model.sort.ticket;
+
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+
+/**
+ * The Class TicketSort represents the sort properties to be associated with the
+ * list ticket request.
+ */
+public class TicketSort extends Sort {
+
+	/**
+	 * Instantiates a new TcketSort.
+	 *
+	 * @param field
+	 *            the field
+	 * @param order
+	 *            the order
+	 */
+	public TicketSort(TicketSortableField field, SortOrder order) {
+		super(field, order);
+	}
+
+}

--- a/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableField.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Enumeration for search request sortable fields.
+ * 
+ * @author tkurzawa 
+ * @since 8 March 2018
  */
 public enum TicketSortableField implements SortableField {
 

--- a/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableField.java
+++ b/src/main/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableField.java
@@ -1,0 +1,87 @@
+package org.zendesk.client.v2.model.sort.ticket;
+
+import org.zendesk.client.v2.model.sort.SortableField;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enumeration for search request sortable fields.
+ */
+public enum TicketSortableField implements SortableField {
+
+	/** The assignee. */
+	ASSIGNEE("assignee"),
+
+	/** The assignee name. */
+	ASSIGNEE_NAME("assignee.name"),
+
+	/** The created at. */
+	CREATED_AT("created_at"),
+
+	/** The group. */
+	GROUP("group"),
+
+	/** The id. */
+	ID("id"),
+
+	/** The locale. */
+	LOCALE("locale"),
+
+	/** The requester. */
+	REQUESTER("requester"),
+
+	/** The requester name. */
+	REQUESTER_NAME("requester.name"),
+
+	/** The status. */
+	STATUS("status"),
+
+	/** The subject. */
+	SUBJECT("subject"),
+
+	/** The updated at. */
+	UPDATED_AT("updated_at");
+
+	/** The keyword. */
+	private String keyword;
+
+	/**
+	 * Instantiates a new TicketSortableField.
+	 *
+	 * @param keyword
+	 *            the keyword
+	 */
+	private TicketSortableField(String keyword) {
+		this.keyword = keyword;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.zendesk.client.v2.model.sort.SortableField#getKeyword()
+	 */
+	@JsonValue
+	public String getKeyword() {
+		return keyword;
+	}
+
+	/**
+	 * Gets the TicketSortableField by keyword.
+	 *
+	 * @param keyword
+	 *            the keyword
+	 * @return the by keyword
+	 */
+	@JsonCreator
+	public static TicketSortableField getByKeyword(String keyword) {
+		TicketSortableField ticketField = null;
+		for (TicketSortableField ticketFieldEnum : TicketSortableField.values()) {
+			if (ticketFieldEnum.getKeyword().equalsIgnoreCase(keyword)) {
+				ticketField = ticketFieldEnum;
+			}
+		}
+		return ticketField;
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/ZendeskTest.java
+++ b/src/test/java/org/zendesk/client/v2/ZendeskTest.java
@@ -1,0 +1,165 @@
+package org.zendesk.client.v2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.zendesk.client.v2.model.SearchResultPage;
+import org.zendesk.client.v2.model.Ticket;
+import org.zendesk.client.v2.model.request.page.SearchPageableRequest;
+import org.zendesk.client.v2.model.request.page.TicketPageableRequest;
+import org.zendesk.client.v2.model.sort.SortOrder;
+import org.zendesk.client.v2.model.sort.search.SearchSort;
+import org.zendesk.client.v2.model.sort.search.SearchSortableField;
+import org.zendesk.client.v2.model.sort.ticket.TicketSort;
+import org.zendesk.client.v2.model.sort.ticket.TicketSortableField;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+public class ZendeskTest {
+	private final static String API_TOKEN = "token";
+	private final static String USERNAME = "user@company.org";
+
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule();
+
+	private Zendesk client;
+
+	@Before
+	public void before() {
+		client = new Zendesk.Builder("http://localhost:8080").setUsername(USERNAME).setToken(API_TOKEN).build();
+	}
+
+	@After
+	public void after() {
+		if (client != null) {
+			client.close();
+		}
+		client = null;
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetTicketsTicketSort_whenSortIsNull_thenIllegalArgumentException() {
+		client.getTickets(null);
+	}
+
+	@Test
+	public void testGetTicketsTicketSort_whenSortPresent_thenSortQueryParamsPresent() {
+		String responseJson = "{\"tickets\":[{\"id\":0,\"subject\":\"ticket0\"},{\"id\":1,\"subject\":\"ticket1\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?page=2&sort_by=id&sort_order=asc\",\"previous_page\":null,\"count\":79686}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/tickets.json")).withQueryParam("sort_by", equalTo("id"))
+				.withQueryParam("sort_order", equalTo("asc")).willReturn(ok().withBody(responseJson)));
+		TicketSort sort = new TicketSort(TicketSortableField.ID, SortOrder.ASC);
+		Iterable<Ticket> iterable = client.getTickets(sort);
+		Iterator<Ticket> iterator = iterable.iterator();
+		assertTrue(iterator.hasNext());
+		assertEquals("ticket0", iterator.next().getSubject());
+		assertEquals("ticket1", iterator.next().getSubject());
+
+		responseJson = "{\"tickets\":[{\"id\":1,\"subject\":\"ticket1\"},{\"id\":2,\"subject\":\"ticket2\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?page=2&sort_by=requester&sort_order=desc\",\"previous_page\":null,\"count\":79686}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/tickets.json")).withQueryParam("sort_by", equalTo("requester"))
+				.withQueryParam("sort_order", equalTo("desc")).willReturn(ok().withBody(responseJson)));
+		sort = new TicketSort(TicketSortableField.REQUESTER, SortOrder.DESC);
+		iterable = client.getTickets(sort);
+		iterator = iterable.iterator();
+		assertTrue(iterator.hasNext());
+		assertEquals("ticket1", iterator.next().getSubject());
+		assertEquals("ticket2", iterator.next().getSubject());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetTicketsPage_whenPageableRequestNull_thenIllegalArgumentException() {
+		client.getTicketsPage(null);
+	}
+
+	@Test
+	public void testGetTicketsPage_whenPageableRequestPresent_thenOk() {
+		String responseJson = "{\"tickets\":[{\"id\":0,\"subject\":\"ticket0\"},{\"id\":1,\"subject\":\"ticket1\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?page=3&per_page=5&sort_by=id&sort_order=asc\",\"previous_page\":\"http://localhost:8080/api/v2/tickets.json?page=1&per_page=5&sort_by=id&sort_order=asc\",\"count\":79686}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/tickets.json")).withQueryParam("page", equalTo("2"))
+				.withQueryParam("per_page", equalTo("5")).withQueryParam("sort_by", equalTo("id"))
+				.withQueryParam("sort_order", equalTo("asc")).willReturn(ok().withBody(responseJson)));
+		TicketSort sort = new TicketSort(TicketSortableField.ID, SortOrder.ASC);
+		TicketPageableRequest request = new TicketPageableRequest(2, 5, sort);
+		SearchResultPage<Ticket> resultPage = client.getTicketsPage(request);
+		assertNotNull(resultPage);
+		assertEquals(79686, resultPage.getCount());
+		assertEquals("http://localhost:8080/api/v2/tickets.json?page=1&per_page=5&sort_by=id&sort_order=asc",
+				resultPage.getPrevPage());
+		assertEquals("http://localhost:8080/api/v2/tickets.json?page=3&per_page=5&sort_by=id&sort_order=asc",
+				resultPage.getNextPage());
+		assertEquals(2, resultPage.getResults().size());
+		assertEquals("ticket0", resultPage.getResults().get(0).getSubject());
+		assertEquals("ticket1", resultPage.getResults().get(1).getSubject());
+	}
+
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testGetSortedSearchResults_whenSortNull_thenIllegalARgumentException() {
+		client.getSortedSearchResults(Ticket.class, "via:api", null);
+	}
+	
+	@Test
+	public void testGetSortedSearchResults_whenSortNotNull_thenOk() {
+		String responseJson = "{\"results\":[{\"id\":0,\"subject\":\"ticket0\"},{\"id\":1,\"subject\":\"ticket1\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=2&sort_by=status&sort_order=asc\",\"previous_page\":null,\"count\":79686}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/search.json")).withQueryParam("sort_by", equalTo("status"))
+				.withQueryParam("sort_order", equalTo("asc"))
+				.withQueryParam("query", equalTo("via:api type:ticket")).willReturn(ok().withBody(responseJson)));
+		
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		Iterable<Ticket> iterable = client.getSortedSearchResults(Ticket.class, "via:api", sort);
+		Iterator<Ticket> iterator = iterable.iterator();
+		assertTrue(iterator.hasNext());
+		assertEquals("ticket0", iterator.next().getSubject());
+		assertEquals("ticket1", iterator.next().getSubject());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testGetSearchResultsPage_whenRequestNull_thenIllegalArgumentException() {
+		client.getSearchResultsPage(Ticket.class, "via:api", null);
+	}
+	@Test
+	public void testGetSearchResultsPage_whenRequestWithSortOnly_thenOk() {
+		String responseJson = "{\"results\":[{\"id\":0,\"subject\":\"ticket0\"},{\"id\":1,\"subject\":\"ticket1\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=2&sort_by=status&sort_order=asc\",\"previous_page\":null,\"count\":111}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/search.json")).withQueryParam("sort_by", equalTo("status"))
+				.withQueryParam("sort_order", equalTo("asc"))
+				.withQueryParam("query", equalTo("via:api type:ticket")).willReturn(ok().withBody(responseJson)));
+		
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		SearchPageableRequest request = new SearchPageableRequest(sort);
+		SearchResultPage<Ticket> searchResultPage = client.getSearchResultsPage(Ticket.class, "via:api", request);
+		assertNotNull(searchResultPage);
+		assertEquals(111, searchResultPage.getCount());
+		assertEquals(2, searchResultPage.getResults().size());
+		assertEquals("http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=2&sort_by=status&sort_order=asc", searchResultPage.getNextPage());
+	}
+	
+	@Test
+	public void testGetSearchResultsPage_whenRequestWithSortAndPage_thenOk() {
+		String responseJson = "{\"results\":[{\"id\":0,\"subject\":\"ticket0\"},{\"id\":1,\"subject\":\"ticket1\"}],\"next_page\":\"http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=3&per_page=5&sort_by=status&sort_order=asc\",\"previous_page\":\"http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=1&per_page=5&sort_by=status&sort_order=asc\",\"count\":222}";
+		wireMockRule.stubFor(get(urlPathEqualTo("/api/v2/search.json")).withQueryParam("sort_by", equalTo("status"))
+				.withQueryParam("sort_order", equalTo("asc"))
+				.withQueryParam("page", equalTo("2")).withQueryParam("per_page", equalTo("5"))
+				.withQueryParam("query", equalTo("via:api type:ticket")).willReturn(ok().withBody(responseJson)));
+		
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		SearchPageableRequest request = new SearchPageableRequest(2, 5, sort);
+		SearchResultPage<Ticket> searchResultPage = client.getSearchResultsPage(Ticket.class, "via:api", request);
+		assertNotNull(searchResultPage);
+		assertEquals(222, searchResultPage.getCount());
+		assertEquals(2, searchResultPage.getResults().size());
+		assertEquals("http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=3&per_page=5&sort_by=status&sort_order=asc", searchResultPage.getNextPage());
+		assertEquals("http://localhost:8080/api/v2/tickets.json?query=via:api+type:ticket&page=1&per_page=5&sort_by=status&sort_order=asc", searchResultPage.getPrevPage());
+	
+	}
+	
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/SearchPageableRequestTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/SearchPageableRequestTest.java
@@ -1,0 +1,63 @@
+package org.zendesk.client.v2.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.request.page.PageableRequest;
+import org.zendesk.client.v2.model.request.page.SearchPageableRequest;
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+import org.zendesk.client.v2.model.sort.search.SearchSort;
+import org.zendesk.client.v2.model.sort.search.SearchSortableField;
+
+public class SearchPageableRequestTest {
+
+	@Test
+	public void testSearchPageableRequestSearchSort() {
+		SearchPageableRequest req = new SearchPageableRequest(null);
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertEquals(null, req.getSort());
+		assertEquals(0, req.getQueryParameters().size());
+
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		req = new SearchPageableRequest(sort);
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertEquals(sort, req.getSort());
+		Map<String, String> map = new HashMap<String, String>();
+		map.put(Sort.SORT_BY, "status");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+	}
+
+	@Test
+	public void testSearchPageableRequestIntIntSearchSort() {
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		SearchPageableRequest req = new SearchPageableRequest(4, 5, sort);
+		assertNotNull(req);
+		assertEquals(4, req.getPage());
+		assertEquals(5, req.getPerPage());
+		assertEquals(sort, req.getSort());
+
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(PageableRequest.PAGE, 4);
+		map.put(PageableRequest.PER_PAGE, 5);
+		map.put(Sort.SORT_BY, "status");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSearchPageableRequestIntIntSearchSort_whenPageNegative_thenException() {
+		SearchSort sort = new SearchSort(SearchSortableField.STATUS, SortOrder.ASC);
+		new SearchPageableRequest(-4, 5, sort);
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/SearchResultPageTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/SearchResultPageTest.java
@@ -1,0 +1,36 @@
+package org.zendesk.client.v2.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.LinkedList;
+
+import org.junit.Test;
+
+public class SearchResultPageTest {
+
+	@Test
+	public void testSearchResultPageLinkedListOfTStringStringInt() {
+		LinkedList<SearchResultEntity> results = new LinkedList<SearchResultEntity>();
+		String nextPage = "nextPage";
+		String prevPage = "prevPage";
+		int count = 123;
+		SearchResultPage<SearchResultEntity> page = new SearchResultPage<>(results, nextPage, prevPage, count);
+		assertNotNull(page);
+		assertEquals(0, page.getResults().size());
+		assertEquals(nextPage, page.getNextPage());
+		assertEquals(prevPage, page.getPrevPage());
+		assertEquals(count, page.getCount());
+	}
+
+	@Test
+	public void testSearchResultPage() {
+		SearchResultPage<SearchResultEntity> page = new SearchResultPage<>();
+		assertNotNull(page);
+		assertEquals(0, page.getResults().size());
+		assertEquals("", page.getNextPage());
+		assertEquals("", page.getPrevPage());
+		assertEquals(0, page.getCount());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/TicketPageableRequestTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/TicketPageableRequestTest.java
@@ -1,0 +1,62 @@
+package org.zendesk.client.v2.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.request.page.PageableRequest;
+import org.zendesk.client.v2.model.request.page.TicketPageableRequest;
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+import org.zendesk.client.v2.model.sort.ticket.TicketSort;
+import org.zendesk.client.v2.model.sort.ticket.TicketSortableField;
+
+public class TicketPageableRequestTest {
+
+	@Test
+	public void testTicketPageableRequestTicketSort() {
+		TicketPageableRequest req = new TicketPageableRequest(null);
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertEquals(null, req.getSort());
+		assertEquals(0, req.getQueryParameters().size());
+
+		TicketSort sort = new TicketSort(TicketSortableField.ID, SortOrder.ASC);
+		req = new TicketPageableRequest(sort);
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertEquals(sort, req.getSort());
+		Map<String, String> map = new HashMap<String, String>();
+		map.put(Sort.SORT_BY, "id");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+	}
+
+	@Test
+	public void testTicketPageableRequestIntIntTicketSort() {
+		TicketSort sort = new TicketSort(TicketSortableField.ID, SortOrder.ASC);
+		TicketPageableRequest req = new TicketPageableRequest(4, 5, sort);
+		assertNotNull(req);
+		assertEquals(4, req.getPage());
+		assertEquals(5, req.getPerPage());
+		assertEquals(sort, req.getSort());
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(PageableRequest.PAGE, 4);
+		map.put(PageableRequest.PER_PAGE, 5);
+		map.put(Sort.SORT_BY, "id");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTicketPageableRequestIntIntTicketSort_whenPageNegative_thenIllegalArgumentException() {
+		TicketSort sort = new TicketSort(TicketSortableField.ID, SortOrder.ASC);
+		new TicketPageableRequest(-4, 5, sort);
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/request/page/PageableRequestTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/request/page/PageableRequestTest.java
@@ -1,0 +1,99 @@
+package org.zendesk.client.v2.model.request.page;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.request.page.PageableRequest;
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+import org.zendesk.client.v2.model.sort.search.SearchSortableField;
+
+public class PageableRequestTest {
+
+	@Test
+	public void testPageableRequestSort() {
+		PageableRequest req = new PageableRequest(null) {
+		};
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertNull(req.getSort());
+
+		Sort sort = new Sort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		req = new PageableRequest(sort) {
+		};
+		assertNotNull(req);
+		assertEquals(0, req.getPage());
+		assertEquals(0, req.getPerPage());
+		assertNotNull(req.getSort());
+	}
+
+	@Test
+	public void testPageableRequestIntIntSort() {
+		PageableRequest req = new PageableRequest(1, 1, null) {
+		};
+		assertNotNull(req);
+		assertEquals(1, req.getPage());
+		assertEquals(1, req.getPerPage());
+		assertNull(req.getSort());
+
+		Sort sort = new Sort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		req = new PageableRequest(2, 3, sort) {
+		};
+		assertNotNull(req);
+		assertEquals(2, req.getPage());
+		assertEquals(3, req.getPerPage());
+		assertNotNull(req.getSort());
+	}
+
+	@Test
+	public void testPageableRequestIntInt() {
+		PageableRequest req = new PageableRequest(3, 5) {
+		};
+		assertNotNull(req);
+		assertEquals(3, req.getPage());
+		assertEquals(5, req.getPerPage());
+		assertNull(req.getSort());
+	}
+
+	@Test
+	public void testToUrl() {
+		PageableRequest req = new PageableRequest(3, 5) {
+		};
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(PageableRequest.PAGE, 3);
+		map.put(PageableRequest.PER_PAGE, 5);
+		assertEquals(map, req.getQueryParameters());
+
+		Sort sort = new Sort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		req = new PageableRequest(2, 3, sort) {
+		};
+		map = new HashMap<String, Object>();
+		map.put(PageableRequest.PAGE, 2);
+		map.put(PageableRequest.PER_PAGE, 3);
+		map.put(Sort.SORT_BY, "created_at");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+
+		req = new PageableRequest(null) {
+		};
+		assertEquals(new HashMap<String, Object>(), req.getQueryParameters());
+
+		req = new PageableRequest(sort) {
+		};
+		map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "created_at");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, req.getQueryParameters());
+
+		req = new PageableRequest(3, 0) {
+		};
+		map = new HashMap<String, Object>();
+		map.put(PageableRequest.PAGE, 3);
+		assertEquals(map, req.getQueryParameters());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/search/FieldSearchTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/FieldSearchTest.java
@@ -1,0 +1,65 @@
+package org.zendesk.client.v2.model.search;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class FieldSearchTest {
+
+	SearchableProperty p = new SearchableProperty() {
+		@Override
+		public String getKeyword() {
+			return "BOO";
+		}
+	};
+	SearchableProperty emptyProperty = new SearchableProperty() {
+		@Override
+		public String getKeyword() {
+			return "";
+		}
+	};
+	
+	@Test
+	public void testFieldSearchSearchablePropertySearchOpString() {
+		FieldSearch fieldSearch = new FieldSearch(p, SearchOp.EQUALS, "abc");
+		assertNotNull(fieldSearch);
+		assertFalse(fieldSearch.isExclude());
+		assertEquals(p, fieldSearch.getProperty());
+		assertEquals(SearchOp.EQUALS, fieldSearch.getOp());
+		assertEquals("abc", fieldSearch.getValue());
+	}
+
+	@Test
+	public void testFieldSearchBooleanSearchablePropertySearchOpString() {
+		FieldSearch fieldSearch = new FieldSearch(true, p, SearchOp.EQUALS, "abc");
+		assertNotNull(fieldSearch);
+		assertTrue(fieldSearch.isExclude());
+		assertEquals(p, fieldSearch.getProperty());
+		assertEquals(SearchOp.EQUALS, fieldSearch.getOp());
+		assertEquals("abc", fieldSearch.getValue());
+	}
+	
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFieldSearch_whenSearchOpNull_thenIllegalArgException() {
+		new FieldSearch(p, null, "value");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testFieldSearch_whenPropertyNull_thenIllegalArgException() {
+		new FieldSearch(null, SearchOp.EQUALS, "value");
+	}
+
+	@Test
+	public void testToString() {
+		FieldSearch fieldSearch = new FieldSearch(p, SearchOp.EQUALS, "abc");
+		assertEquals("BOO:abc", fieldSearch.toString());
+		fieldSearch = new FieldSearch(p, SearchOp.LESS_THAN, 5);
+		assertEquals("BOO<5", fieldSearch.toString());
+		fieldSearch = new FieldSearch(true, p, SearchOp.GREATER_THAN_OR_EQUAL, 5);
+		assertEquals("-BOO>=5", fieldSearch.toString());
+		fieldSearch = new FieldSearch(emptyProperty, SearchOp.EQUALS, "abc");
+		assertEquals("abc", fieldSearch.toString());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/search/QueryBuilderTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/QueryBuilderTest.java
@@ -1,0 +1,36 @@
+package org.zendesk.client.v2.model.search;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class QueryBuilderTest {
+
+	SearchableProperty property = new SearchableProperty() {
+		@Override
+		public String getKeyword() {
+			return "field";
+		}
+	};
+
+	@Test
+	public void testBuild() {
+		QueryBuilder builder = new QueryBuilder();
+		assertEquals("", builder.build());		
+		builder = new QueryBuilder().addFieldSearch(new FieldSearch(property, SearchOp.EQUALS, "a"));
+		assertEquals("field:a", builder.build());
+		builder = new QueryBuilder().addFieldSearch(new FieldSearch(property, SearchOp.LESS_THAN, 5)).addFieldSearch(new FieldSearch(property, SearchOp.GREATER_THAN, 10));
+		assertEquals("field<5 field>10", builder.build());
+		builder = builder.addPhraseSearch("abcd");
+		assertEquals("field<5 field>10 \"abcd\"", builder.build());
+		builder = builder.addFieldSearch(new FieldSearch(property, SearchOp.EQUALS, "xyz"));
+		assertEquals("field<5 field>10 field:xyz \"abcd\"", builder.build());
+		builder = builder.addPhraseSearch("qwert");
+		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\"", builder.build());
+		builder = builder.setResultType(SearchResultType.TICKET);
+		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\" type:ticket", builder.build());
+		builder = builder.setResultType(SearchResultType.ARTICLE);
+		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\" type:article", builder.build());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/search/QueryBuilderTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/QueryBuilderTest.java
@@ -29,8 +29,6 @@ public class QueryBuilderTest {
 		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\"", builder.build());
 		builder = builder.setResultType(SearchResultType.TICKET);
 		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\" type:ticket", builder.build());
-		builder = builder.setResultType(SearchResultType.ARTICLE);
-		assertEquals("field<5 field>10 field:xyz \"abcd\" \"qwert\" type:article", builder.build());
 	}
 
 }

--- a/src/test/java/org/zendesk/client/v2/model/search/SearchOpTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/SearchOpTest.java
@@ -1,0 +1,35 @@
+package org.zendesk.client.v2.model.search;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SearchOpTest {
+
+	@Test
+	public void testGetOp() {
+		assertEquals(":", SearchOp.EQUALS.getOp());
+		assertEquals(">", SearchOp.GREATER_THAN.getOp());
+		assertEquals(">=", SearchOp.GREATER_THAN_OR_EQUAL.getOp());
+		assertEquals("<", SearchOp.LESS_THAN.getOp());
+		assertEquals("<=", SearchOp.LESS_THAN_OR_EQUAL.getOp());
+	}
+
+	@Test
+	public void testGetByOp() {
+		assertEquals(SearchOp.EQUALS, SearchOp.getByOp(":"));
+		assertEquals(SearchOp.EQUALS, SearchOp.getByOp(" : "));
+		assertEquals(SearchOp.GREATER_THAN, SearchOp.getByOp(">"));
+		assertEquals(SearchOp.GREATER_THAN, SearchOp.getByOp(">   "));
+		assertEquals(SearchOp.GREATER_THAN_OR_EQUAL, SearchOp.getByOp(">="));
+		assertEquals(SearchOp.GREATER_THAN_OR_EQUAL, SearchOp.getByOp("  >="));
+		assertEquals(SearchOp.LESS_THAN, SearchOp.getByOp("<"));
+		assertEquals(SearchOp.LESS_THAN, SearchOp.getByOp("< "));
+		assertEquals(SearchOp.LESS_THAN_OR_EQUAL, SearchOp.getByOp("<="));
+		assertEquals(SearchOp.LESS_THAN_OR_EQUAL, SearchOp.getByOp("<=   "));
+
+		assertNull(SearchOp.getByOp("<>"));
+		assertNull(SearchOp.getByOp(null));
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/search/SearchResultTypeTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/SearchResultTypeTest.java
@@ -1,0 +1,35 @@
+package org.zendesk.client.v2.model.search;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.Group;
+import org.zendesk.client.v2.model.Organization;
+import org.zendesk.client.v2.model.Ticket;
+import org.zendesk.client.v2.model.Topic;
+import org.zendesk.client.v2.model.User;
+import org.zendesk.client.v2.model.hc.Article;
+
+public class SearchResultTypeTest {
+
+	@Test
+	public void testGetName() {
+		assertEquals("article", SearchResultType.ARTICLE.getName());
+		assertEquals("group", SearchResultType.GROUP.getName());
+		assertEquals("organization", SearchResultType.ORGANIZATION.getName());
+		assertEquals("ticket", SearchResultType.TICKET.getName());
+		assertEquals("topic", SearchResultType.TOPIC.getName());
+		assertEquals("user", SearchResultType.USER.getName());
+	}
+
+	@Test
+	public void testGetTypeClass() {
+		assertEquals(Article.class, SearchResultType.ARTICLE.getTypeClass());
+		assertEquals(Group.class, SearchResultType.GROUP.getTypeClass());
+		assertEquals(Organization.class, SearchResultType.ORGANIZATION.getTypeClass());
+		assertEquals(Ticket.class, SearchResultType.TICKET.getTypeClass());
+		assertEquals(Topic.class, SearchResultType.TOPIC.getTypeClass());
+		assertEquals(User.class, SearchResultType.USER.getTypeClass());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/search/SearchResultTypeTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/SearchResultTypeTest.java
@@ -1,34 +1,28 @@
 package org.zendesk.client.v2.model.search;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.zendesk.client.v2.model.Group;
 import org.zendesk.client.v2.model.Organization;
 import org.zendesk.client.v2.model.Ticket;
-import org.zendesk.client.v2.model.Topic;
 import org.zendesk.client.v2.model.User;
-import org.zendesk.client.v2.model.hc.Article;
 
 public class SearchResultTypeTest {
 
 	@Test
 	public void testGetName() {
-		assertEquals("article", SearchResultType.ARTICLE.getName());
 		assertEquals("group", SearchResultType.GROUP.getName());
 		assertEquals("organization", SearchResultType.ORGANIZATION.getName());
 		assertEquals("ticket", SearchResultType.TICKET.getName());
-		assertEquals("topic", SearchResultType.TOPIC.getName());
 		assertEquals("user", SearchResultType.USER.getName());
 	}
 
 	@Test
 	public void testGetTypeClass() {
-		assertEquals(Article.class, SearchResultType.ARTICLE.getTypeClass());
 		assertEquals(Group.class, SearchResultType.GROUP.getTypeClass());
 		assertEquals(Organization.class, SearchResultType.ORGANIZATION.getTypeClass());
 		assertEquals(Ticket.class, SearchResultType.TICKET.getTypeClass());
-		assertEquals(Topic.class, SearchResultType.TOPIC.getTypeClass());
 		assertEquals(User.class, SearchResultType.USER.getTypeClass());
 	}
 

--- a/src/test/java/org/zendesk/client/v2/model/search/ticket/TicketSearchablePropertyTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/search/ticket/TicketSearchablePropertyTest.java
@@ -1,0 +1,82 @@
+package org.zendesk.client.v2.model.search.ticket;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TicketSearchablePropertyTest {
+
+	@Test
+	public void testGetKeyword() {
+		assertEquals("assignee", TicketSearchableProperty.ASSIGNEE.getKeyword());
+		assertEquals("brand", TicketSearchableProperty.BRAND.getKeyword());
+		assertEquals("cc", TicketSearchableProperty.CC.getKeyword());
+		assertEquals("commenter", TicketSearchableProperty.COMMENTER.getKeyword());
+		assertEquals("created", TicketSearchableProperty.CREATED.getKeyword());
+		assertEquals("fieldvalue", TicketSearchableProperty.CUSTOM_FIELD.getKeyword());
+		assertEquals("description", TicketSearchableProperty.DESCRIPTION.getKeyword());
+		assertEquals("due_date", TicketSearchableProperty.DUE_DATE.getKeyword());
+		assertEquals("group", TicketSearchableProperty.GROUP.getKeyword());
+		assertEquals("", TicketSearchableProperty.ID.getKeyword());
+		assertEquals("organization", TicketSearchableProperty.ORGANIZATION.getKeyword());
+		assertEquals("priority", TicketSearchableProperty.PRIORITY.getKeyword());
+		assertEquals("requester", TicketSearchableProperty.REQUESTER.getKeyword());
+		assertEquals("solved", TicketSearchableProperty.SOLVED.getKeyword());
+		assertEquals("status", TicketSearchableProperty.STATUS.getKeyword());
+		assertEquals("subject", TicketSearchableProperty.SUBJECT.getKeyword());
+		assertEquals("submitter", TicketSearchableProperty.SUBMITTER.getKeyword());
+		assertEquals("tags", TicketSearchableProperty.TAGS.getKeyword());
+		assertEquals("ticket_type", TicketSearchableProperty.TICKET_TYPE.getKeyword());
+		assertEquals("updated", TicketSearchableProperty.UPDATED.getKeyword());
+		assertEquals("via", TicketSearchableProperty.VIA.getKeyword());
+	}
+
+	@Test
+	public void testGetByKeyword() {
+		assertEquals(TicketSearchableProperty.ASSIGNEE, TicketSearchableProperty.getByKeyword("assignee"));
+		assertEquals(TicketSearchableProperty.ASSIGNEE, TicketSearchableProperty.getByKeyword("AssigneE"));
+		assertEquals(TicketSearchableProperty.BRAND, TicketSearchableProperty.getByKeyword("brand"));
+		assertEquals(TicketSearchableProperty.BRAND, TicketSearchableProperty.getByKeyword("branD"));
+		assertEquals(TicketSearchableProperty.CC, TicketSearchableProperty.getByKeyword("cc"));
+		assertEquals(TicketSearchableProperty.CC, TicketSearchableProperty.getByKeyword("CC"));
+		assertEquals(TicketSearchableProperty.COMMENTER, TicketSearchableProperty.getByKeyword("commenter"));
+		assertEquals(TicketSearchableProperty.COMMENTER, TicketSearchableProperty.getByKeyword("commenteR"));
+		assertEquals(TicketSearchableProperty.CREATED, TicketSearchableProperty.getByKeyword("created"));
+		assertEquals(TicketSearchableProperty.CREATED, TicketSearchableProperty.getByKeyword("createD"));
+		assertEquals(TicketSearchableProperty.CUSTOM_FIELD, TicketSearchableProperty.getByKeyword("fieldvalue"));
+		assertEquals(TicketSearchableProperty.CUSTOM_FIELD, TicketSearchableProperty.getByKeyword("fieldvaluE"));
+		assertEquals(TicketSearchableProperty.DESCRIPTION, TicketSearchableProperty.getByKeyword("description"));
+		assertEquals(TicketSearchableProperty.DESCRIPTION, TicketSearchableProperty.getByKeyword("descriptioN"));
+		assertEquals(TicketSearchableProperty.DUE_DATE, TicketSearchableProperty.getByKeyword("due_date"));
+		assertEquals(TicketSearchableProperty.DUE_DATE, TicketSearchableProperty.getByKeyword("due_datE"));
+		assertEquals(TicketSearchableProperty.GROUP, TicketSearchableProperty.getByKeyword("group"));
+		assertEquals(TicketSearchableProperty.GROUP, TicketSearchableProperty.getByKeyword("grouP"));
+		assertEquals(TicketSearchableProperty.ID, TicketSearchableProperty.getByKeyword(""));
+		assertEquals(TicketSearchableProperty.ID, TicketSearchableProperty.getByKeyword("  "));
+		assertEquals(TicketSearchableProperty.ORGANIZATION, TicketSearchableProperty.getByKeyword("organization"));
+		assertEquals(TicketSearchableProperty.ORGANIZATION, TicketSearchableProperty.getByKeyword("organizatioN "));
+		assertEquals(TicketSearchableProperty.PRIORITY, TicketSearchableProperty.getByKeyword("priority"));
+		assertEquals(TicketSearchableProperty.PRIORITY, TicketSearchableProperty.getByKeyword(" prioritY "));
+		assertEquals(TicketSearchableProperty.REQUESTER, TicketSearchableProperty.getByKeyword("requester"));
+		assertEquals(TicketSearchableProperty.REQUESTER, TicketSearchableProperty.getByKeyword(" REQUESTER "));
+		assertEquals(TicketSearchableProperty.SOLVED, TicketSearchableProperty.getByKeyword("solved"));
+		assertEquals(TicketSearchableProperty.SOLVED, TicketSearchableProperty.getByKeyword("solveD"));
+		assertEquals(TicketSearchableProperty.STATUS, TicketSearchableProperty.getByKeyword("status"));
+		assertEquals(TicketSearchableProperty.STATUS, TicketSearchableProperty.getByKeyword("statuS"));
+		assertEquals(TicketSearchableProperty.SUBJECT, TicketSearchableProperty.getByKeyword("subject"));
+		assertEquals(TicketSearchableProperty.SUBJECT, TicketSearchableProperty.getByKeyword("subjecT"));
+		assertEquals(TicketSearchableProperty.SUBMITTER, TicketSearchableProperty.getByKeyword("submitter"));
+		assertEquals(TicketSearchableProperty.SUBMITTER, TicketSearchableProperty.getByKeyword("submitter   "));
+		assertEquals(TicketSearchableProperty.TAGS, TicketSearchableProperty.getByKeyword("tags"));
+		assertEquals(TicketSearchableProperty.TAGS, TicketSearchableProperty.getByKeyword("taGS  "));
+		assertEquals(TicketSearchableProperty.TICKET_TYPE, TicketSearchableProperty.getByKeyword("ticket_type"));
+		assertEquals(TicketSearchableProperty.TICKET_TYPE, TicketSearchableProperty.getByKeyword("   ticket_type"));
+		assertEquals(TicketSearchableProperty.UPDATED, TicketSearchableProperty.getByKeyword("updatED  "));
+		assertEquals(TicketSearchableProperty.UPDATED, TicketSearchableProperty.getByKeyword("updated"));
+		assertEquals(TicketSearchableProperty.VIA, TicketSearchableProperty.getByKeyword("via"));
+		assertEquals(TicketSearchableProperty.VIA, TicketSearchableProperty.getByKeyword("VIA"));
+		
+		assertNull(TicketSearchableProperty.getByKeyword(null));
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/SortOrderTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/SortOrderTest.java
@@ -1,0 +1,29 @@
+package org.zendesk.client.v2.model.sort;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SortOrderTest {
+
+	@Test
+	public void testGetOrder() {
+		assertEquals("asc", SortOrder.ASC.getOrder());
+		assertEquals("desc", SortOrder.DESC.getOrder());
+	}
+
+	@Test
+	public void testGetByOrder() {
+		assertEquals(SortOrder.ASC, SortOrder.getByOrder("asc"));
+		assertEquals(SortOrder.ASC, SortOrder.getByOrder("aSc"));
+		assertEquals(SortOrder.ASC, SortOrder.getByOrder("ASC"));
+
+		assertEquals(SortOrder.DESC, SortOrder.getByOrder("desc"));
+		assertEquals(SortOrder.DESC, SortOrder.getByOrder("dESc"));
+		assertEquals(SortOrder.DESC, SortOrder.getByOrder("DESC"));
+		
+		assertNull(SortOrder.getByOrder("order"));
+		assertNull(SortOrder.getByOrder(null));
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/SortTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/SortTest.java
@@ -1,0 +1,50 @@
+package org.zendesk.client.v2.model.sort;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.sort.search.SearchSortableField;
+
+public class SortTest {
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testSort_whenFieldAndOrderNull_thenIllegalArgumentException() {
+		new Sort(null, null);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSort_whenOrderNull_thenIllegalArgumentException() {
+		new Sort(SearchSortableField.CREATED_AT, null);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSort_whenFieldNull_thenIllegalArgumentException() {
+		new Sort(null, SortOrder.ASC);
+	}
+	
+	@Test
+	public void testSort_whenFieldAndOrderNotNull_thenObjectCreated() {
+		Sort sort = new Sort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		assertNotNull(sort);
+		assertEquals(SearchSortableField.CREATED_AT, sort.getField());
+		assertEquals(SortOrder.ASC, sort.getOrder());
+	}
+
+	@Test
+	public void testToUrl() {
+		Sort sort = new Sort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "created_at");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, sort.getQueryParameters());
+		sort = new Sort(SearchSortableField.PRIORITY, SortOrder.DESC);
+		map.put(Sort.SORT_BY, "priority");
+		map.put(Sort.SORT_ORDER, "desc");
+		assertEquals(map, sort.getQueryParameters());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/search/SearchSortTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/search/SearchSortTest.java
@@ -1,0 +1,51 @@
+package org.zendesk.client.v2.model.sort.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+
+public class SearchSortTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSearchSort_whenFieldAndOrderAreNull_thenIllegalArgumentException() {
+		new SearchSort(null, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSearchSort_whenOrderNull_thenIllegalArgumentException() {
+		new SearchSort(SearchSortableField.CREATED_AT, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSearchSort_whenFieldNull_thenIllegalArgumentException() {
+		new SearchSort(null, SortOrder.ASC);
+	}
+
+	public void testSearchSort_whenFieldAndOrderNotNull_thenObjectCreated() {
+		SearchSort sort = new SearchSort(SearchSortableField.CREATED_AT, SortOrder.ASC);
+		assertNotNull(sort);
+		assertEquals(SearchSortableField.CREATED_AT, sort.getField());
+		assertEquals(SortOrder.ASC, sort.getOrder());
+	}
+
+	@Test
+	public void testToUrl() {
+		SearchSort sort = new SearchSort(SearchSortableField.UPDATED_AT, SortOrder.ASC);
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "updated_at");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, sort.getQueryParameters());
+		sort = new SearchSort(SearchSortableField.PRIORITY, SortOrder.DESC);
+		map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "priority");
+		map.put(Sort.SORT_ORDER, "desc");
+		assertEquals(map, sort.getQueryParameters());
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/search/SearchSortableFieldTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/search/SearchSortableFieldTest.java
@@ -1,0 +1,44 @@
+package org.zendesk.client.v2.model.sort.search;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SearchSortableFieldTest {
+
+	@Test
+	public void testGetKeyword() {
+		assertEquals("created_at", SearchSortableField.CREATED_AT.getKeyword());
+		assertEquals("priority", SearchSortableField.PRIORITY.getKeyword());
+		assertEquals("status", SearchSortableField.STATUS.getKeyword());
+		assertEquals("ticket_type", SearchSortableField.TICKET_TYPE.getKeyword());
+		assertEquals("updated_at", SearchSortableField.UPDATED_AT.getKeyword());
+	}
+
+	@Test
+	public void testGetByKeyword() {
+		assertEquals(SearchSortableField.CREATED_AT, SearchSortableField.getByKeyword("created_at"));
+		assertEquals(SearchSortableField.CREATED_AT, SearchSortableField.getByKeyword("created_AT"));
+		assertEquals(SearchSortableField.CREATED_AT, SearchSortableField.getByKeyword("CREATED_AT"));
+
+		assertEquals(SearchSortableField.PRIORITY, SearchSortableField.getByKeyword("priority"));
+		assertEquals(SearchSortableField.PRIORITY, SearchSortableField.getByKeyword("PRIORITY"));
+		assertEquals(SearchSortableField.PRIORITY, SearchSortableField.getByKeyword("priORity"));
+
+		assertEquals(SearchSortableField.STATUS, SearchSortableField.getByKeyword("status"));
+		assertEquals(SearchSortableField.STATUS, SearchSortableField.getByKeyword("staTUs"));
+		assertEquals(SearchSortableField.STATUS, SearchSortableField.getByKeyword("STATUS"));
+
+		assertEquals(SearchSortableField.TICKET_TYPE, SearchSortableField.getByKeyword("ticket_type"));
+		assertEquals(SearchSortableField.TICKET_TYPE, SearchSortableField.getByKeyword("tickEt_Type"));
+		assertEquals(SearchSortableField.TICKET_TYPE, SearchSortableField.getByKeyword("TICKET_TYPE"));
+
+		assertEquals(SearchSortableField.UPDATED_AT, SearchSortableField.getByKeyword("updated_at"));
+		assertEquals(SearchSortableField.UPDATED_AT, SearchSortableField.getByKeyword("updated_AT"));
+		assertEquals(SearchSortableField.UPDATED_AT, SearchSortableField.getByKeyword("UPDATED_AT"));
+
+		assertNull(SearchSortableField.getByKeyword("abc"));
+		assertNull(SearchSortableField.getByKeyword(null));
+	}
+
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/ticket/TicketSortTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/ticket/TicketSortTest.java
@@ -1,0 +1,50 @@
+package org.zendesk.client.v2.model.sort.ticket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.zendesk.client.v2.model.sort.Sort;
+import org.zendesk.client.v2.model.sort.SortOrder;
+
+public class TicketSortTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTicketSort_whenFieldAndOrderAreNull_thenIllegalArgumentException() {
+		new TicketSort(null, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTicketSort_whenOrderNull_thenIllegalArgumentException() {
+		new TicketSort(TicketSortableField.CREATED_AT, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTicketSort_whenFieldNull_thenIllegalArgumentException() {
+		new TicketSort(null, SortOrder.ASC);
+	}
+
+	public void testTicketSort_whenFieldAndOrderNotNull_thenObjectCreated() {
+		TicketSort sort = new TicketSort(TicketSortableField.CREATED_AT, SortOrder.ASC);
+		assertNotNull(sort);
+		assertEquals(TicketSortableField.CREATED_AT, sort.getField());
+		assertEquals(SortOrder.ASC, sort.getOrder());
+	}
+
+	@Test
+	public void testToUrl() {
+		TicketSort sort = new TicketSort(TicketSortableField.CREATED_AT, SortOrder.ASC);
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "created_at");
+		map.put(Sort.SORT_ORDER, "asc");
+		assertEquals(map, sort.getQueryParameters());
+		sort = new TicketSort(TicketSortableField.ASSIGNEE, SortOrder.DESC);
+		map = new HashMap<String, Object>();
+		map.put(Sort.SORT_BY, "assignee");
+		map.put(Sort.SORT_ORDER, "desc");
+		assertEquals(map, sort.getQueryParameters());
+	}
+}

--- a/src/test/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableFieldTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/sort/ticket/TicketSortableFieldTest.java
@@ -1,0 +1,65 @@
+package org.zendesk.client.v2.model.sort.ticket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class TicketSortableFieldTest {
+
+	@Test
+	public void testGetKeyword() {
+		assertEquals("assignee", TicketSortableField.ASSIGNEE.getKeyword());
+		assertEquals("assignee.name", TicketSortableField.ASSIGNEE_NAME.getKeyword());
+		assertEquals("created_at", TicketSortableField.CREATED_AT.getKeyword());
+		assertEquals("group", TicketSortableField.GROUP.getKeyword());
+		assertEquals("id", TicketSortableField.ID.getKeyword());
+		assertEquals("locale", TicketSortableField.LOCALE.getKeyword());
+		assertEquals("requester", TicketSortableField.REQUESTER.getKeyword());
+		assertEquals("requester.name", TicketSortableField.REQUESTER_NAME.getKeyword());
+		assertEquals("status", TicketSortableField.STATUS.getKeyword());
+		assertEquals("subject", TicketSortableField.SUBJECT.getKeyword());
+		assertEquals("updated_at", TicketSortableField.UPDATED_AT.getKeyword());
+	}
+
+	@Test
+	public void testGetByKeyword() {
+		assertEquals(TicketSortableField.ASSIGNEE, TicketSortableField.getByKeyword("assignee"));
+		assertEquals(TicketSortableField.ASSIGNEE, TicketSortableField.getByKeyword("assignEE"));
+
+		assertEquals(TicketSortableField.ASSIGNEE_NAME, TicketSortableField.getByKeyword("assignee.name"));
+		assertEquals(TicketSortableField.ASSIGNEE_NAME, TicketSortableField.getByKeyword("assignee.NAME"));
+
+		assertEquals(TicketSortableField.CREATED_AT, TicketSortableField.getByKeyword("created_at"));
+		assertEquals(TicketSortableField.CREATED_AT, TicketSortableField.getByKeyword("created_AT"));
+
+		assertEquals(TicketSortableField.GROUP, TicketSortableField.getByKeyword("group"));
+		assertEquals(TicketSortableField.GROUP, TicketSortableField.getByKeyword("GRoup"));
+
+		assertEquals(TicketSortableField.ID, TicketSortableField.getByKeyword("id"));
+		assertEquals(TicketSortableField.ID, TicketSortableField.getByKeyword("ID"));
+
+		assertEquals(TicketSortableField.LOCALE, TicketSortableField.getByKeyword("locale"));
+		assertEquals(TicketSortableField.LOCALE, TicketSortableField.getByKeyword("loCale"));
+
+		assertEquals(TicketSortableField.REQUESTER, TicketSortableField.getByKeyword("requester"));
+		assertEquals(TicketSortableField.REQUESTER, TicketSortableField.getByKeyword("requesTEr"));
+
+		assertEquals(TicketSortableField.REQUESTER_NAME, TicketSortableField.getByKeyword("requester.name"));
+		assertEquals(TicketSortableField.REQUESTER_NAME, TicketSortableField.getByKeyword("REQUESTER.name"));
+
+		assertEquals(TicketSortableField.STATUS, TicketSortableField.getByKeyword("status"));
+		assertEquals(TicketSortableField.STATUS, TicketSortableField.getByKeyword("statuS"));
+
+		assertEquals(TicketSortableField.SUBJECT, TicketSortableField.getByKeyword("subject"));
+		assertEquals(TicketSortableField.SUBJECT, TicketSortableField.getByKeyword("subjeCT"));
+
+		assertEquals(TicketSortableField.UPDATED_AT, TicketSortableField.getByKeyword("updated_at"));
+		assertEquals(TicketSortableField.UPDATED_AT, TicketSortableField.getByKeyword("UPDATED_at"));
+
+		assertNull(TicketSortableField.getByKeyword("abc"));
+		assertNull(TicketSortableField.getByKeyword(""));
+		assertNull(TicketSortableField.getByKeyword("null"));
+	}
+
+}


### PR DESCRIPTION
Added implementation for sorting and return of the single page of the entities by the tickets.json and search.json endpoints. Sorting and specific pagination requests have been added to already existing methods for tickets and search endpoints. Implemented QueryBuilder class to simplify creation of the more complex queries.
Implemented junit test cases using wiremock.