### PR TITLE
[fix] The build is failing because SonarQube requires Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,22 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Maven
-        run: mvn --show-version --no-transfer-progress verify sonar:sonar --file pom.xml -Dsonar.organization=cloudbees -Dsonar.host.url=${SONAR_URL} -Dsonar.login=${SONAR_TOKEN} -Pcoverage
+        run: mvn --show-version --no-transfer-progress verify --file pom.xml -Pcoverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_URL: ${{ secrets.SONAR_URL }}
           ZENDESK_JAVA_CLIENT_TEST_URL: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_URL }}
           ZENDESK_JAVA_CLIENT_TEST_USERNAME: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_USERNAME }}
           ZENDESK_JAVA_CLIENT_TEST_PASSWORD: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_PASSWORD }}
           ZENDESK_JAVA_CLIENT_TEST_TOKEN: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_TOKEN }}
           ZENDESK_JAVA_CLIENT_TEST_REQUESTER_EMAIL: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_REQUESTER_EMAIL }}
           ZENDESK_JAVA_CLIENT_TEST_REQUESTER_NAME: ${{ secrets.ZENDESK_JAVA_CLIENT_TEST_REQUESTER_NAME }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Analyze with SonarQube
+        run: mvn --show-version --no-transfer-progress sonar:sonar --file pom.xml -Dsonar.organization=cloudbees -Dsonar.host.url=${SONAR_URL} -Dsonar.login=${SONAR_TOKEN}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_URL: ${{ secrets.SONAR_URL }}


### PR DESCRIPTION
```
Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.8.0.2131:sonar (default-cli) on project zendesk-java-client: 
Error:  
Error:  The version of Java (1.8.0_282) you have used to run this analysis is deprecated and we stopped accepting it.
Error:  Please update to at least Java 11. You can find more information here: ***/documentation/upcoming/
Error:  
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```

