### PR TITLE
Configure the DefaultAsyncHttpClient to follow redirects

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.asynchttpclient.AsyncCompletionHandler;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Realm;
 import org.asynchttpclient.Request;
@@ -102,6 +103,8 @@ import java.util.regex.Pattern;
  */
 public class Zendesk implements Closeable {
     private static final String JSON = "application/json; charset=UTF-8";
+    private static final DefaultAsyncHttpClientConfig DEFAULT_ASYNC_HTTP_CLIENT_CONFIG =
+            new DefaultAsyncHttpClientConfig.Builder().setFollowRedirect(true).build();
     private final boolean closeClient;
     private final AsyncHttpClient client;
     private final Realm realm;
@@ -147,7 +150,7 @@ public class Zendesk implements Closeable {
         this.logger = LoggerFactory.getLogger(Zendesk.class);
         this.closeClient = client == null;
         this.oauthToken = null;
-        this.client = client == null ? new DefaultAsyncHttpClient() : client;
+        this.client = client == null ? new DefaultAsyncHttpClient(DEFAULT_ASYNC_HTTP_CLIENT_CONFIG) : client;
         this.url = url.endsWith("/") ? url + "api/v2" : url + "/api/v2";
         if (username != null) {
             this.realm = new Realm.Builder(username, password)
@@ -169,7 +172,7 @@ public class Zendesk implements Closeable {
         this.logger = LoggerFactory.getLogger(Zendesk.class);
         this.closeClient = client == null;
         this.realm = null;
-        this.client = client == null ? new DefaultAsyncHttpClient() : client;
+        this.client = client == null ? new DefaultAsyncHttpClient(DEFAULT_ASYNC_HTTP_CLIENT_CONFIG) : client;
         this.url = url.endsWith("/") ? url + "api/v2" : url + "/api/v2";
         if (oauthToken != null) {
             this.oauthToken = oauthToken;


### PR DESCRIPTION
It seems that Zendesk started to emit some redirects when iterating on multi-pages results.

Maybe because we use a custom domain? The problem started yesterday.

```
Exception in thread "main" org.zendesk.client.v2.ZendeskResponseException: HTTP/302: Found - You are being redirected to https://foo.zendesk.com/access/return_to?challenge=XXXXXXX&locale=en-US-x-1&return_to=https%3A%2F%2Fsupport.foo.com%2Fapi%2Fv2%2Ftickets%2F210487%2Fcomments.json%3Fsort_order%3Dasc
	at org.zendesk.client.v2.Zendesk.complete(Zendesk.java:2539)
	at org.zendesk.client.v2.Zendesk.access$1400(Zendesk.java:100)
	at org.zendesk.client.v2.Zendesk$PagedIterable$PagedIterator.hasNext(Zendesk.java:2805)
```