### PR TITLE
Increate ITs timeout to 60s

### DIFF
--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -114,7 +114,7 @@ public class RealSmokeTest {
      * Global timeout applied on each test to avoid to wait forever if something goes wrong with the remote server
      */
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(30);
+    public Timeout globalTimeout = Timeout.seconds(60);
 
     @BeforeClass
     public static void loadConfig() {


### PR DESCRIPTION
They are failing on CI and locally with 30s

It should fix our ITs which are executed and failing on master