### PR TITLE
Add test for Action.toString

### DIFF
--- a/src/test/java/org/zendesk/client/v2/model/ActionTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/ActionTest.java
@@ -42,4 +42,11 @@ public class ActionTest {
         assertEquals("huu", action.getValue()[0]);
         assertEquals("haa", action.getValue()[1]);
     }
+
+    @Test
+    public void testToString() {
+        String json = "{ \"field\": 21337631753, \"value\": \"huuhaa\" }";
+        Action action = parseJson(json.getBytes());
+        assertEquals("Action{field=\'21337631753\', value=[huuhaa]}", action.toString());
+    }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `action.toString()` is equal to `"Action{field=\'21337631753\', value=[huuhaa]}"`.
This tests the method [`Action.toString`](https://github.com/cloudbees-oss/zendesk-java-client/blob/8a045fdc5bda665ef2cfb33b445027348c7ccbcc/src/main/java/org/zendesk/client/v2/model/Action.java#L44).
This test is based on the test [`testActionWithSingleValue`](https://github.com/cloudbees-oss/zendesk-java-client/blob/8a045fdc5bda665ef2cfb33b445027348c7ccbcc/src/test/java/org/zendesk/client/v2/model/ActionTest.java#L27).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))