### PR TITLE
Add Automatic-Module-Name to manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,18 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+              <archive>
+                  <manifestEntries>
+                      <Automatic-Module-Name>org.zendesk.client.v2</Automatic-Module-Name>
+                  </manifestEntries>
+              </archive>
+          </configuration>
+      </plugin>
     </plugins>
   </build>
   


### PR DESCRIPTION
Use maven-jar-plugin to add `Automatic-Module-Name: org.zendesk.client.v2` to the manifest. This makes it easier to use with Java 9+ in a modular projects