### PR TITLE
Implement getUsersByExternalIds(String, String...) - resolves #548

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -932,6 +932,11 @@ public class Zendesk implements Closeable {
                 handleList(User.class, "users")));
     }
 
+   public List<User> getUsersByExternalIds(String externalId, String... externalIds) {
+        return complete(submit(req("GET", tmpl("/users/show_many.json{?external_ids}").set("external_ids", idArray(externalId, externalIds))),
+                handleList(User.class, "users")));
+    }
+
     public Iterable<User> getUsersIncrementally(Date startTime) {
         return new PagedIterable<>(
                 tmpl("/incremental/users.json{?start_time}").set("start_time", msToSeconds(startTime.getTime())),
@@ -3098,6 +3103,15 @@ public class Zendesk implements Closeable {
         List<Long> result = new ArrayList<>(ids.length + 1);
         result.add(id);
         for (long i : ids) {
+            result.add(i);
+        }
+        return result;
+    }
+
+    private static List<String> idArray(String id, String... ids) {
+        List<String> result = new ArrayList<>(ids.length + 1);
+        result.add(id);
+        for (String i : ids) {
             result.add(i);
         }
         return result;

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -927,6 +927,11 @@ public class Zendesk implements Closeable {
                 handleList(User.class, "users")));
     }
 
+    /**
+     * @deprecated - User externalIds are Strings in Zendesk API, not longs.
+     * Use {@link #getUsersByExternalIds(String, String...)} instead
+     */
+    @Deprecated
     public List<User> getUsersByExternalIds(long externalId, long... externalIds) {
         return complete(submit(req("GET", tmpl("/users/show_many.json{?external_ids}").set("external_ids", idArray(externalId, externalIds))),
                 handleList(User.class, "users")));

--- a/src/main/java/org/zendesk/client/v2/model/User.java
+++ b/src/main/java/org/zendesk/client/v2/model/User.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author stephenc
@@ -396,4 +397,39 @@ public class User extends Collaborator implements SearchResultEntity, Serializab
         this.reportCsv = reportCsv;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id) && Objects.equals(url, user.url) &&
+                Objects.equals(externalId, user.externalId) && Objects.equals(alias, user.alias) &&
+                Objects.equals(createdAt, user.createdAt) && Objects.equals(updatedAt, user.updatedAt) &&
+                Objects.equals(active, user.active) && Objects.equals(verified, user.verified) &&
+                Objects.equals(shared, user.shared) && Objects.equals(localeId, user.localeId) &&
+                Objects.equals(locale, user.locale) && Objects.equals(timeZone, user.timeZone) &&
+                Objects.equals(lastLoginAt, user.lastLoginAt) && Objects.equals(phone, user.phone) &&
+                Objects.equals(restrictedAgent, user.restrictedAgent) && Objects.equals(signature, user.signature) &&
+                Objects.equals(details, user.details) && Objects.equals(notes, user.notes) &&
+                Objects.equals(organizationId, user.organizationId) && role == user.role &&
+                Objects.equals(customRoleId, user.customRoleId) && Objects.equals(moderator, user.moderator) &&
+                ticketRestriction == user.ticketRestriction &&
+                Objects.equals(onlyPrivateComments, user.onlyPrivateComments) &&
+                Objects.equals(tags, user.tags) && Objects.equals(suspended, user.suspended) &&
+                Objects.equals(photo, user.photo) && Objects.equals(identities, user.identities) &&
+                Objects.equals(remotePhotoUrl, user.remotePhotoUrl) && Objects.equals(userFields, user.userFields) &&
+                Objects.equals(chatOnly, user.chatOnly) && Objects.equals(sharedPhoneNumber, user.sharedPhoneNumber) &&
+                Objects.equals(defaultGroupId, user.defaultGroupId) && Objects.equals(roleType, user.roleType) &&
+                Objects.equals(twoFactorAuthEnabled, user.twoFactorAuthEnabled) &&
+                Objects.equals(reportCsv, user.reportCsv);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, url, externalId, alias, createdAt, updatedAt, active, verified, shared, localeId,
+                locale, timeZone, lastLoginAt, phone, restrictedAgent, signature, details, notes, organizationId,
+                role, customRoleId, moderator, ticketRestriction, onlyPrivateComments, tags, suspended, photo,
+                identities, remotePhotoUrl, userFields, chatOnly, sharedPhoneNumber, defaultGroupId, roleType,
+                twoFactorAuthEnabled, reportCsv);
+    }
 }

--- a/src/test/java/org/zendesk/client/v2/UserTest.java
+++ b/src/test/java/org/zendesk/client/v2/UserTest.java
@@ -1,6 +1,15 @@
 package org.zendesk.client.v2;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,7 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 
-import java.util.ArrayList;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/org/zendesk/client/v2/UserTest.java
+++ b/src/test/java/org/zendesk/client/v2/UserTest.java
@@ -1,12 +1,6 @@
 package org.zendesk.client.v2;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.put;
-import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,7 +8,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.text.RandomStringGenerator;
 import org.junit.After;
 import org.junit.Before;
@@ -107,5 +106,52 @@ public class UserTest {
                 .isNotNull()
                 .isEqualToComparingFieldByField(userObjectInResponse);
 
+    }
+
+    @Test
+    public void getUsersByExternalIds_canBeCalledWithEitherLongsOrStrings() throws JsonProcessingException {
+
+        User user123 = new User();
+        user123.setId(1L);
+        user123.setExternalId("123");
+        user123.setName("user123");
+        User user456 = new User();
+        user456.setId(2L);
+        user456.setExternalId("456");
+        user456.setName("user456");
+        User user789 = new User();
+        user789.setId(3L);
+        user789.setExternalId("789");
+        user789.setName("user789");
+
+        String expectedJsonResponse = objectMapper.writeValueAsString(
+                Collections.singletonMap("users", Arrays.asList(user123, user456, user789)));
+
+        zendeskApiMock.stubFor(
+                get(
+                        urlPathEqualTo("/api/v2/users/show_many.json"))
+                        .withQueryParam("external_ids", equalTo("123,456,789"))
+                        .willReturn(ok()
+                                .withBody(expectedJsonResponse)
+                        )
+        );
+
+        List<User> usersByLongExternalIds = client.getUsersByExternalIds(123, 456, 789);
+
+        zendeskApiMock.verify(getRequestedFor(
+                urlPathEqualTo("/api/v2/users/show_many.json"))
+                .withQueryParam("external_ids", equalTo("123,456,789"))
+        );
+
+        assertThat(usersByLongExternalIds).containsExactly(user123, user456, user789);
+
+        List<User> usersByStringExternalIds = client.getUsersByExternalIds("123", "456", "789");
+
+        zendeskApiMock.verify(getRequestedFor(
+                urlPathEqualTo("/api/v2/users/show_many.json"))
+                .withQueryParam("external_ids", equalTo("123,456,789"))
+        );
+
+        assertThat(usersByStringExternalIds).containsExactly(user123, user456, user789);
     }
 }

--- a/src/test/java/org/zendesk/client/v2/UserTest.java
+++ b/src/test/java/org/zendesk/client/v2/UserTest.java
@@ -1,6 +1,5 @@
 package org.zendesk.client.v2;
 
-
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/src/test/java/org/zendesk/client/v2/UserTest.java
+++ b/src/test/java/org/zendesk/client/v2/UserTest.java
@@ -136,7 +136,7 @@ public class UserTest {
                         )
         );
 
-        List<User> usersByLongExternalIds = client.getUsersByExternalIds(123, 456, 789);
+        List<User> usersByLongExternalIds = client.getUsersByExternalIds(123L, 456L, 789L);
 
         zendeskApiMock.verify(getRequestedFor(
                 urlPathEqualTo("/api/v2/users/show_many.json"))


### PR DESCRIPTION
User external IDs are Strings in the Zendesk API, but the existing getUsersByExternalId implementation only allowed getting users by an externalId that was a long.