### PR TITLE
Add support for `Article.content_tag_ids field` - resolves #557

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/hc/Article.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/Article.java
@@ -40,6 +40,10 @@ public class Article implements SearchResultEntity {
     @JsonProperty("comments_disabled")
     private Boolean commentsDisabled;
 
+    /** The list of content tags attached to the article */
+    @JsonProperty("content_tag_ids")
+    private List<Long> contentTagIds;
+
     /** Whether the source (default) translation of the article is out of date */
     private Boolean outdated;
 
@@ -166,6 +170,14 @@ public class Article implements SearchResultEntity {
         this.commentsDisabled = commentsDisabled;
     }
 
+    public List<Long> getContentTagIds() {
+        return contentTagIds;
+    }
+
+    public void setContentTagIds(List<Long> contentTagIds) {
+        this.contentTagIds = contentTagIds;
+    }
+
     public Boolean getOutdated() {
         return outdated;
     }
@@ -290,6 +302,7 @@ public class Article implements SearchResultEntity {
                 ", sourceLocale='" + sourceLocale + '\'' +
                 ", authorId=" + authorId +
                 ", commentsDisabled=" + commentsDisabled +
+                ", contentTagIds=" + contentTagIds +
                 ", outdated=" + outdated +
                 ", outdatedLocales=" + outdatedLocales +
                 ", labelNames=" + labelNames +

--- a/src/test/java/org/zendesk/client/v2/model/ArticleTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/ArticleTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.zendesk.client.v2.model.hc.Article;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
@@ -31,6 +32,7 @@ public class ArticleTest {
                 "\"html_url\":\"https://example.zendesk.com/hc/en-us/articles/918273645013-Welcome-to-your-Help-Center-\"," +
                 "\"author_id\":2314596780," +
                 "\"comments_disabled\":false," +
+                "\"content_tag_ids\": [335, 7104]," +
                 "\"draft\":false," +
                 "\"promoted\":false," +
                 "\"position\":0," +
@@ -57,6 +59,7 @@ public class ArticleTest {
         assertEquals("https://example.zendesk.com/hc/en-us/articles/918273645013-Welcome-to-your-Help-Center-", article.getHtmlUrl());
         assertEquals((Long) 2314596780L, article.getAuthorId());
         assertEquals(false, article.getCommentsDisabled());
+        assertEquals(Arrays.asList(335L, 7104L), article.getContentTagIds());
         assertEquals(false, article.getDraft());
         assertEquals(false, article.getPromoted());
         assertEquals((Long) 0L, article.getPosition());


### PR DESCRIPTION
N.B. a potential risk of adding a new field to the model seems to be that any existing code using the client that was doing a overwrite of an existing article (by calling Zendesk.updateArticle(article) (without having recently read the article in question from the API, or where the Article instance has been created by copying a known set of fields from another Article instance) would have been preserving any pre-existing content_tags_id value on the article.
But if we add the field to the model, then any code like this will now be updating the content_tags_id field to be empty
This edge-case change in behaviour seems worthwhile, but may be worth documenting in release notes.