### PR TITLE
Support the 'Content Tags' resource in the Zendesk API - resolves #559

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -63,6 +63,7 @@ import org.zendesk.client.v2.model.dynamic.DynamicContentItemVariant;
 import org.zendesk.client.v2.model.hc.Article;
 import org.zendesk.client.v2.model.hc.ArticleAttachments;
 import org.zendesk.client.v2.model.hc.Category;
+import org.zendesk.client.v2.model.hc.ContentTag;
 import org.zendesk.client.v2.model.hc.Locales;
 import org.zendesk.client.v2.model.hc.PermissionGroup;
 import org.zendesk.client.v2.model.hc.Section;
@@ -2534,6 +2535,32 @@ public class Zendesk implements Closeable {
             handleList(Holiday.class, "holidays")));
     }
 
+    public ContentTag getContentTag(String contentTagId) {
+        return complete(submit(req("GET", tmpl("/guide/content_tags/{id}").set("id", contentTagId)),
+                handle(ContentTag.class, "content_tag")));
+    }
+
+    public ContentTag createContentTag(ContentTag contentTag) {
+        checkHasName(contentTag);
+        return complete(submit(req("POST", tmpl("/guide/content_tags"),
+                JSON, json(Collections.singletonMap("content_tag", contentTag))),
+                handle(ContentTag.class, "content_tag")));
+    }
+
+    public ContentTag updateContentTag(ContentTag contentTag) {
+        checkHasId(contentTag);
+        checkHasName(contentTag);
+        return complete(submit(req("PUT", tmpl("/guide/content_tags/{id}").set("id", contentTag.getId()),
+                        JSON, json(Collections.singletonMap("content_tag", contentTag))),
+                handle(ContentTag.class, "content_tag")));
+    }
+
+    public void deleteContentTag(ContentTag contentTag) {
+        checkHasId(contentTag);
+        complete(submit(req("DELETE", tmpl("/guide/content_tags/{id}").set("id", contentTag.getId())),
+                handleStatus()));
+    }
+
     //////////////////////////////////////////////////////////////////////
     // Helper methods
     //////////////////////////////////////////////////////////////////////
@@ -3129,6 +3156,18 @@ public class Zendesk implements Closeable {
     private static void checkHasId(UserSegment userSegment) {
         if (userSegment.getId() == null) {
             throw new IllegalArgumentException("UserSegment requires id");
+        }
+    }
+
+    private static void checkHasId(ContentTag contentTag) {
+        if (contentTag.getId() == null) {
+            throw new IllegalArgumentException("Content Tag requires id");
+        }
+    }
+
+    private static void checkHasName(ContentTag contentTag) {
+        if (contentTag.getName() == null || contentTag.getName().trim().isEmpty()) {
+            throw new IllegalArgumentException("Content Tag requires name");
         }
     }
 

--- a/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
@@ -28,6 +28,16 @@ public class ContentTag {
     @JsonProperty("updated_at")
     private Date updatedAt;
 
+    public ContentTag() {
+    }
+
+    public ContentTag(String id, String name, Date createdAt, Date updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
     public String getId() {
         return id;
     }

--- a/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 
 /**
  * You can assign a content tag to posts and articles to loosely group them together.
- * </p>
  * For more information, see <a href="https://support.zendesk.com/hc/en-us/articles/4848925672730">About Content tags</a>
  * in Zendesk help.
  */

--- a/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ContentTag.java
@@ -1,0 +1,85 @@
+package org.zendesk.client.v2.model.hc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * You can assign a content tag to posts and articles to loosely group them together.
+ * </p>
+ * For more information, see <a href="https://support.zendesk.com/hc/en-us/articles/4848925672730">About Content tags</a>
+ * in Zendesk help.
+ */
+public class ContentTag {
+
+    /** Automatically assigned when the content tag is created.
+     * N.B. unlike many other entities, the id field is a String, not a Long */
+    private String id;
+
+    /** The name of the content tag */
+    private String name;
+
+    /** The time the content tag was created */
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    /** The time the content tag was last updated */
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ContentTag that = (ContentTag) o;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt, that.updatedAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, createdAt, updatedAt);
+    }
+
+    @Override
+    public String toString() {
+        return "ContentTag{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
+    }
+}

--- a/src/test/java/org/zendesk/client/v2/ContentTagsTest.java
+++ b/src/test/java/org/zendesk/client/v2/ContentTagsTest.java
@@ -1,0 +1,117 @@
+package org.zendesk.client.v2;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import org.apache.commons.text.RandomStringGenerator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.zendesk.client.v2.model.hc.ContentTag;
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ContentTagsTest {
+
+    private static final String MOCK_URL_FORMATTED_STRING = "http://localhost:%d";
+    public static final RandomStringGenerator RANDOM_STRING_GENERATOR =
+            new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+    private static final String MOCK_API_TOKEN = RANDOM_STRING_GENERATOR.generate(15);
+    private static final String MOCK_USERNAME = RANDOM_STRING_GENERATOR.generate(10).toLowerCase() + "@cloudbees.com";
+
+    @ClassRule
+    public static WireMockClassRule zendeskApiClass = new WireMockClassRule(options()
+            .dynamicPort()
+            .dynamicHttpsPort()
+            .usingFilesUnderClasspath("wiremock")
+    );
+
+    @Rule
+    public WireMockClassRule zendeskApiMock = zendeskApiClass;
+
+    private Zendesk client;
+
+    @Before
+    public void setUp() throws Exception {
+        int ephemeralPort = zendeskApiMock.port();
+
+        String hostname = String.format(MOCK_URL_FORMATTED_STRING, ephemeralPort);
+
+        client = new Zendesk.Builder(hostname)
+                .setUsername(MOCK_USERNAME)
+                .setToken(MOCK_API_TOKEN)
+                .build();
+    }
+
+    @After
+    public void closeClient() {
+        if (client != null) {
+            client.close();
+        }
+        client = null;
+    }
+
+    @Test
+    public void getContentTags_willPageOverMultiplePages() throws Exception {
+        zendeskApiMock.stubFor(
+                get(
+                        urlPathEqualTo("/api/v2/guide/content_tags"))
+                        .withQueryParam("page%5Bsize%5D", equalTo("2"))
+                        .willReturn(ok()
+                                .withBodyFile("content_tags/content_tag_search_first_page.json")
+                        )
+        );
+        zendeskApiMock.stubFor(
+                get(
+                        urlPathEqualTo("/api/v2/guide/content_tags"))
+                        .withQueryParam("page%5Bsize%5D", equalTo("2"))
+                        .withQueryParam("page%5Bafter%5D", equalTo("first_after_cursor"))
+                        .willReturn(ok()
+                                .withBodyFile("content_tags/content_tag_search_second_page.json")
+                        )
+        );
+        zendeskApiMock.stubFor(
+                get(
+                        urlPathEqualTo("/api/v2/guide/content_tags"))
+                        .withQueryParam("page%5Bsize%5D", equalTo("2"))
+                        .withQueryParam("page%5Bafter%5D", equalTo("second_after_cursor"))
+                        .willReturn(ok()
+                                .withBodyFile("content_tags/content_tag_search_third_page.json")
+                        )
+        );
+
+        Iterable<ContentTag> actualResults = client.getContentTags(2);
+
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        assertThat(actualResults).containsExactly(
+                new ContentTag("11111111111111111111111111", "first name",
+                        df.parse("2023-03-13 10:01:00"),
+                        df.parse("2023-03-13 10:01:01")
+                ),
+                new ContentTag("22222222222222222222222222", "second name",
+                        df.parse("2023-03-13 10:02:00"),
+                        df.parse("2023-03-13 10:02:02")
+                ),
+                new ContentTag("33333333333333333333333333", "third name",
+                        df.parse("2023-03-13 10:03:00"),
+                        df.parse("2023-03-13 10:03:03")
+                ),
+                new ContentTag("44444444444444444444444444", "fourth name",
+                        df.parse("2023-03-13 10:04:00"),
+                        df.parse("2023-03-13 10:04:04")
+                ),
+                new ContentTag("55555555555555555555555555", "fifth name",
+                        df.parse("2023-03-13 10:05:00"),
+                        df.parse("2023-03-13 10:05:05")
+                )
+        );
+    }
+}

--- a/src/test/java/org/zendesk/client/v2/model/hc/ContentTagTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/hc/ContentTagTest.java
@@ -1,0 +1,47 @@
+package org.zendesk.client.v2.model.hc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ContentTagTest {
+
+    private ContentTag parseJson(byte[] json) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue(json, ContentTag.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Test
+    public void testParsePermissionGroup() throws ParseException {
+        String json = "{\n" +
+                "  \"created_at\": \"2022-10-13T12:34:56.000Z\",\n" +
+                "  \"id\": \"01GFXGBX7YZ9ASWTCVMASTK8ZS\",\n" +
+                "  \"name\": \"feature request\",\n" +
+                "  \"updated_at\": \"2022-10-13T13:44:55.000Z\"\n" +
+                "}";
+        ContentTag ct = parseJson(json.getBytes());
+
+        assertNotNull(ct);
+        assertEquals(ContentTag.class, ct.getClass());
+        assertEquals("01GFXGBX7YZ9ASWTCVMASTK8ZS", ct.getId());
+        assertEquals("feature request", ct.getName());
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+        Date created = simpleDateFormat.parse("2022-10-13 12:34:56 +0000");
+        assertEquals(created, ct.getCreatedAt());
+        Date updated = simpleDateFormat.parse("2022-10-13 13:44:55 +0000");
+        assertEquals(updated, ct.getUpdatedAt());
+    }
+
+}

--- a/src/test/resources/wiremock/__files/content_tags/content_tag_search_first_page.json
+++ b/src/test/resources/wiremock/__files/content_tags/content_tag_search_first_page.json
@@ -1,0 +1,21 @@
+{
+  "records": [
+    {
+      "id": "11111111111111111111111111",
+      "name": "first name",
+      "created_at": "2023-03-13T10:01:00.000Z",
+      "updated_at": "2023-03-13T10:01:01.000Z"
+    },
+    {
+      "id": "22222222222222222222222222",
+      "name": "second name",
+      "created_at": "2023-03-13T10:02:00.000Z",
+      "updated_at": "2023-03-13T10:02:02.000Z"
+    }
+  ],
+  "meta": {
+    "has_more": true,
+    "after_cursor": "first_after_cursor",
+    "before_cursor": "first_before_cursor"
+  }
+}

--- a/src/test/resources/wiremock/__files/content_tags/content_tag_search_second_page.json
+++ b/src/test/resources/wiremock/__files/content_tags/content_tag_search_second_page.json
@@ -1,0 +1,21 @@
+{
+  "records": [
+    {
+      "id": "33333333333333333333333333",
+      "name": "third name",
+      "created_at": "2023-03-13T10:03:00.000Z",
+      "updated_at": "2023-03-13T10:03:03.000Z"
+    },
+    {
+      "id": "44444444444444444444444444",
+      "name": "fourth name",
+      "created_at": "2023-03-13T10:04:00.000Z",
+      "updated_at": "2023-03-13T10:04:04.000Z"
+    }
+  ],
+  "meta": {
+    "has_more": true,
+    "after_cursor": "second_after_cursor",
+    "before_cursor": "second_before_cursor"
+  }
+}

--- a/src/test/resources/wiremock/__files/content_tags/content_tag_search_third_page.json
+++ b/src/test/resources/wiremock/__files/content_tags/content_tag_search_third_page.json
@@ -1,0 +1,15 @@
+{
+  "records": [
+    {
+      "id": "55555555555555555555555555",
+      "name": "fifth name",
+      "created_at": "2023-03-13T10:05:00.000Z",
+      "updated_at": "2023-03-13T10:05:05.000Z"
+    }
+  ],
+  "meta": {
+    "has_more": false,
+    "after_cursor": "third_after_cursor",
+    "before_cursor": "third_before_cursor"
+  }
+}


### PR DESCRIPTION
Content Tags can be added to posts and articles to loosely group them together.
The resource is a small object {id, name, createdDate, updatedDate}
The API supports CRUD & some searching

**Additional context**
API documentation: https://developer.zendesk.com/api-reference/help_center/help-center-api/content_tags/
Article about how they are used: https://support.zendesk.com/hc/en-us/articles/4848925672730