### PR TITLE
Users by role cursor pagination

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -911,11 +911,11 @@ public class Zendesk implements Closeable {
         // Going to have to build this URI manually, because the RFC6570 template spec doesn't support
         // variables like ?role[]=...role[]=..., which is what Zendesk requires.
         // See https://developer.zendesk.com/rest_api/docs/core/users#filters
-        final StringBuilder uriBuilder = new StringBuilder("/users.json");
+        final StringBuilder uriBuilder = new StringBuilder("/users.json?page[size]=100");
         if (roles.length == 0) {
-            uriBuilder.append("?role=").append(encodeUrl(role));
+            uriBuilder.append("&role=").append(encodeUrl(role));
         } else {
-            uriBuilder.append("?role[]=").append(encodeUrl(role));
+            uriBuilder.append("&role[]=").append(encodeUrl(role));
         }
         for (final String curRole : roles) {
             uriBuilder.append("&role[]=").append(encodeUrl(curRole));


### PR DESCRIPTION
Added cursor pagination to getUserByRole and added a basic unit test for the method. I avoided adding admin users for the unit test. I didn't think that would be a good idea or allowed in the test environment.