### PR TITLE
Bugfix - Article.contentTagIds field now List<String> - resolves #581

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/hc/Article.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/Article.java
@@ -42,7 +42,7 @@ public class Article implements SearchResultEntity {
 
     /** The list of content tags attached to the article */
     @JsonProperty("content_tag_ids")
-    private List<Long> contentTagIds;
+    private List<String> contentTagIds;
 
     /** Whether the source (default) translation of the article is out of date */
     private Boolean outdated;
@@ -170,11 +170,11 @@ public class Article implements SearchResultEntity {
         this.commentsDisabled = commentsDisabled;
     }
 
-    public List<Long> getContentTagIds() {
+    public List<String> getContentTagIds() {
         return contentTagIds;
     }
 
-    public void setContentTagIds(List<Long> contentTagIds) {
+    public void setContentTagIds(List<String> contentTagIds) {
         this.contentTagIds = contentTagIds;
     }
 

--- a/src/test/java/org/zendesk/client/v2/model/ArticleTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/ArticleTest.java
@@ -32,7 +32,7 @@ public class ArticleTest {
                 "\"html_url\":\"https://example.zendesk.com/hc/en-us/articles/918273645013-Welcome-to-your-Help-Center-\"," +
                 "\"author_id\":2314596780," +
                 "\"comments_disabled\":false," +
-                "\"content_tag_ids\": [335, 7104]," +
+                "\"content_tag_ids\": [\"01GMAGH6KPDHEY79MN3S4H8V7D\", \"01GFXGBX7YZ9ASWTCVMASTK8ZS\"]," +
                 "\"draft\":false," +
                 "\"promoted\":false," +
                 "\"position\":0," +
@@ -59,7 +59,7 @@ public class ArticleTest {
         assertEquals("https://example.zendesk.com/hc/en-us/articles/918273645013-Welcome-to-your-Help-Center-", article.getHtmlUrl());
         assertEquals((Long) 2314596780L, article.getAuthorId());
         assertEquals(false, article.getCommentsDisabled());
-        assertEquals(Arrays.asList(335L, 7104L), article.getContentTagIds());
+        assertEquals(Arrays.asList("01GMAGH6KPDHEY79MN3S4H8V7D","01GFXGBX7YZ9ASWTCVMASTK8ZS"), article.getContentTagIds());
         assertEquals(false, article.getDraft());
         assertEquals(false, article.getPromoted());
         assertEquals((Long) 0L, article.getPosition());


### PR DESCRIPTION
The Article.contentTagIds field had been added with the incorrect type of List<Long> (because of misleading Zendesk documentation), but the IDs are actually `String`s & so can't be deserialised to Longs