### PR TITLE
Removed variables with duplicate definitions in Ticket/Request

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Ticket.java
+++ b/src/main/java/org/zendesk/client/v2/model/Ticket.java
@@ -16,8 +16,6 @@ public class Ticket extends Request implements SearchResultEntity {
     private static final long serialVersionUID = 1L;
 
     private String externalId;
-    private Type type;
-    private Priority priority;
     private String recipient;
     private Long submitterId;
     private Long assigneeId;
@@ -29,7 +27,6 @@ public class Ticket extends Request implements SearchResultEntity {
     private boolean hasIncidents;
     private Date dueAt;
     private List<String> tags;
-    private List<CustomFieldValue> customFields;
     private SatisfactionRating satisfactionRating;
     private List<Long> sharingAgreementIds;
     private List<Long> followupIds;
@@ -77,15 +74,6 @@ public class Ticket extends Request implements SearchResultEntity {
 
     public void setCollaborators(List<Collaborator> collaborators) {
         this.collaborators = collaborators;
-    }
-
-    @JsonProperty("custom_fields")
-    public List<CustomFieldValue> getCustomFields() {
-        return customFields;
-    }
-
-    public void setCustomFields(List<CustomFieldValue> customFields) {
-        this.customFields = customFields;
     }
 
     @JsonProperty("due_at")
@@ -140,14 +128,6 @@ public class Ticket extends Request implements SearchResultEntity {
 
     public void setHasIncidents(boolean hasIncidents) {
         this.hasIncidents = hasIncidents;
-    }
-
-    public Priority getPriority() {
-        return priority;
-    }
-
-    public void setPriority(Priority priority) {
-        this.priority = priority;
     }
 
     @JsonProperty("problem_id")
@@ -229,14 +209,6 @@ public class Ticket extends Request implements SearchResultEntity {
 
     public void setTicketFormId(Long ticketFormId) {
         this.ticketFormId = ticketFormId;
-    }
-
-    public Type getType() {
-        return type;
-    }
-
-    public void setType(Type type) {
-        this.type = type;
     }
 
     @JsonProperty("is_public")

--- a/src/main/java/org/zendesk/client/v2/model/Ticket.java
+++ b/src/main/java/org/zendesk/client/v2/model/Ticket.java
@@ -13,7 +13,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Ticket extends Request implements SearchResultEntity {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -7559199410302237012L;
 
     private String externalId;
     private String recipient;


### PR DESCRIPTION
Fixes cloudbees-oss/zendesk-java-client#573

Very simple/small fix, but will allow library to work correctly in an environment where GSON is used.