### PR TITLE
Add default user agent header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,9 @@
         <version>3.3.0</version>
         <configuration>
           <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
             <manifestEntries>
               <Automatic-Module-Name>org.zendesk.client.v2</Automatic-Module-Name>
             </manifestEntries>

--- a/src/main/java/org/zendesk/client/v2/DefaultUserAgent.java
+++ b/src/main/java/org/zendesk/client/v2/DefaultUserAgent.java
@@ -1,0 +1,24 @@
+package org.zendesk.client.v2;
+
+import java.util.regex.Pattern;
+
+public class DefaultUserAgent {
+  private static final Pattern VERSION_PATTERN = Pattern.compile("[\\w-.]+");
+  private final String userAgent;
+
+  public DefaultUserAgent() {
+    this(DefaultUserAgent.class.getPackage().getImplementationVersion());
+  }
+
+  public DefaultUserAgent(String version) {
+    StringBuilder sb = new StringBuilder("zendesk-java-client");
+    if (version != null && VERSION_PATTERN.matcher(version).matches()) {
+      sb.append('/').append(version);
+    }
+    this.userAgent = sb.toString();
+  }
+
+  public String toString() {
+    return this.userAgent;
+  }
+}

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -107,6 +107,7 @@ import org.zendesk.client.v2.model.targets.UrlTarget;
  */
 public class Zendesk implements Closeable {
   private static final String JSON = "application/json; charset=UTF-8";
+  private static final String USER_AGENT_HEADER = "User-Agent";
   private static final DefaultAsyncHttpClientConfig DEFAULT_ASYNC_HTTP_CLIENT_CONFIG =
       new DefaultAsyncHttpClientConfig.Builder().setFollowRedirect(true).build();
   private final boolean closeClient;
@@ -176,6 +177,7 @@ public class Zendesk implements Closeable {
       }
       this.realm = null;
     }
+    headers.putIfAbsent(USER_AGENT_HEADER, new DefaultUserAgent().toString());
     this.headers = Collections.unmodifiableMap(headers);
     this.mapper = createMapper();
   }
@@ -194,6 +196,7 @@ public class Zendesk implements Closeable {
       throw new IllegalStateException(
           "Cannot specify token or password without specifying username");
     }
+    headers.putIfAbsent(USER_AGENT_HEADER, new DefaultUserAgent().toString());
     this.headers = Collections.unmodifiableMap(headers);
 
     this.mapper = createMapper();

--- a/src/test/java/org/zendesk/client/v2/DefaultUserAgentTest.java
+++ b/src/test/java/org/zendesk/client/v2/DefaultUserAgentTest.java
@@ -1,0 +1,33 @@
+package org.zendesk.client.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class DefaultUserAgentTest {
+  @Test
+  public void testDefaultVersion() {
+    assertThat(new DefaultUserAgent().toString()).startsWith("zendesk-java-client");
+  }
+
+  @Test
+  public void testNullVersion() {
+    assertThat(new DefaultUserAgent(null).toString()).isEqualTo("zendesk-java-client");
+  }
+
+  @Test
+  public void testInvalidVersion() {
+    assertThat(new DefaultUserAgent("???").toString()).isEqualTo("zendesk-java-client");
+  }
+
+  @Test
+  public void testSnapshotVersion() {
+    assertThat(new DefaultUserAgent("0.1.2-SNAPSHOT").toString())
+        .isEqualTo("zendesk-java-client/0.1.2-SNAPSHOT");
+  }
+
+  @Test
+  public void testReleaseVersion() {
+    assertThat(new DefaultUserAgent("0.1.2").toString()).isEqualTo("zendesk-java-client/0.1.2");
+  }
+}


### PR DESCRIPTION
Adds a default user-agent header to requests made by the client. This helps identify traffic coming from the client, but doesn't prevent users from supplying their own user-agent header.

This is slightly modified from the version found in https://github.com/cloudbees-oss/zendesk-java-client/pull/608. It requires that the version be written into the manifest which is accomplished by `addDefaultImplementationEntries`