### PR TITLE
Add Ticket properties to support safe update

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Ticket.java
+++ b/src/main/java/org/zendesk/client/v2/model/Ticket.java
@@ -222,7 +222,7 @@ public class Ticket extends Request implements SearchResultEntity {
   }
 
   /**
-   * The safe_update & update_stamp parameters are used by the Zendesk API to protect against update
+   * The safe_update &amp; update_stamp parameters are used by the Zendesk API to protect against update
    * collisions. If the safe_update parameter is set to true and Zendesk detects that a ticket has
    * been updated since the time specified in update_stamp then it will return an HTTP CONFLICT
    * status to let the caller know that the ticket was not successfully updated.

--- a/src/main/java/org/zendesk/client/v2/model/Ticket.java
+++ b/src/main/java/org/zendesk/client/v2/model/Ticket.java
@@ -1,6 +1,8 @@
 package org.zendesk.client.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.List;
@@ -32,6 +34,7 @@ public class Ticket extends Request implements SearchResultEntity {
   private Long ticketFormId;
   private Long brandId;
   private Boolean isPublic;
+  private Boolean safeUpdate;
 
   public Ticket() {}
 
@@ -218,6 +221,34 @@ public class Ticket extends Request implements SearchResultEntity {
     this.isPublic = isPublic;
   }
 
+  /**
+   * The safe_update & update_stamp parameters are used by the Zendesk API to protect against update
+   * collisions. If the safe_update parameter is set to true and Zendesk detects that a ticket has
+   * been updated since the time specified in update_stamp then it will return an HTTP CONFLICT
+   * status to let the caller know that the ticket was not successfully updated.
+   *
+   * <p>These properties are annotated with JsonInclude(Include.NON_DEFAULT) so that they will only
+   * be serialized to JSON if safeUpdate is set to TRUE.
+   *
+   * <p>For more information see Zendesk documentation at:
+   * https://developer.zendesk.com/documentation/ticketing/managing-tickets/creating-and-updating-tickets/#protecting-against-ticket-update-collisions
+   */
+  @JsonInclude(Include.NON_DEFAULT)
+  @JsonProperty("safe_update")
+  public Boolean getSafeUpdate() {
+    return safeUpdate;
+  }
+
+  public void setSafeUpdate(Boolean safeUpdate) {
+    this.safeUpdate = safeUpdate;
+  }
+
+  @JsonInclude(Include.NON_DEFAULT)
+  @JsonProperty("updated_stamp")
+  private Date getUpdatedStamp() {
+    return Boolean.TRUE.equals(safeUpdate) ? updatedAt : null;
+  }
+
   @Override
   public String toString() {
     return "Ticket"
@@ -285,6 +316,8 @@ public class Ticket extends Request implements SearchResultEntity {
         + brandId
         + ", isPublic="
         + isPublic
+        + ", safeUpdate="
+        + safeUpdate
         + ", createdAt="
         + createdAt
         + ", updatedAt="

--- a/src/main/java/org/zendesk/client/v2/model/Ticket.java
+++ b/src/main/java/org/zendesk/client/v2/model/Ticket.java
@@ -222,10 +222,10 @@ public class Ticket extends Request implements SearchResultEntity {
   }
 
   /**
-   * The safe_update &amp; update_stamp parameters are used by the Zendesk API to protect against update
-   * collisions. If the safe_update parameter is set to true and Zendesk detects that a ticket has
-   * been updated since the time specified in update_stamp then it will return an HTTP CONFLICT
-   * status to let the caller know that the ticket was not successfully updated.
+   * The safe_update &amp; update_stamp parameters are used by the Zendesk API to protect against
+   * update collisions. If the safe_update parameter is set to true and Zendesk detects that a
+   * ticket has been updated since the time specified in update_stamp then it will return an HTTP
+   * CONFLICT status to let the caller know that the ticket was not successfully updated.
    *
    * <p>These properties are annotated with JsonInclude(Include.NON_DEFAULT) so that they will only
    * be serialized to JSON if safeUpdate is set to TRUE.

--- a/src/test/java/org/zendesk/client/v2/model/TicketTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/TicketTest.java
@@ -1,0 +1,54 @@
+package org.zendesk.client.v2.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Random;
+import org.junit.Test;
+import org.zendesk.client.v2.Zendesk;
+
+public class TicketTest {
+
+  private static final Random RANDOM = new Random();
+  private static final String TICKET_COMMENT1 = "Please ignore this ticket";
+  private static final Date NOW = Calendar.getInstance().getTime();
+
+  @Test
+  public void serializeWithNullSafeUpdate() throws Exception {
+    ObjectMapper mapper = Zendesk.createMapper();
+    Ticket ticket = createSampleTicket();
+    assertThat(mapper.writeValueAsString(ticket))
+        .doesNotContain("\"safe_update\"")
+        .doesNotContain("\"updated_stamp\"");
+  }
+
+  @Test
+  public void serializeWithFalseSafeUpdate() throws Exception {
+    ObjectMapper mapper = Zendesk.createMapper();
+    Ticket ticket = createSampleTicket();
+    ticket.setSafeUpdate(false);
+    assertThat(mapper.writeValueAsString(ticket))
+        .doesNotContain("\"safe_update\"")
+        .doesNotContain("\"updated_stamp\"");
+  }
+
+  @Test
+  public void serializeWithSafeUpdate() throws Exception {
+    ObjectMapper mapper = Zendesk.createMapper();
+    Ticket ticket = createSampleTicket();
+    ticket.setSafeUpdate(true);
+    assertThat(mapper.writeValueAsString(ticket))
+        .contains("\"safe_update\"")
+        .contains("\"updated_stamp\"");
+  }
+
+  private Ticket createSampleTicket() {
+    Ticket ticket = new Ticket();
+    ticket.setId(Math.abs(RANDOM.nextLong()));
+    ticket.setComment(new Comment(TICKET_COMMENT1));
+    ticket.setUpdatedAt(NOW);
+    return ticket;
+  }
+}


### PR DESCRIPTION
#629 
This change adds the `safe_update` and `updated_stamp` properties to the `Ticket` class to support Zendesk's protection against ticket update collisions as described in [the Zendesk documentation](https://developer.zendesk.com/documentation/ticketing/managing-tickets/creating-and-updating-tickets/#protecting-against-ticket-update-collisions).

These properties will only serialize into JSON when `safe_update` is set to TRUE.

I've added some unit tests for serialization and have performed some manual tests to validate:
- Attempting to update a ticket with `safe_update` set to true can succeed.
- Attempting to update an out-of-date ticket with `safe_update` set to true will result in a HTTP CONFLICT status.
- Attempting to update an out-of-date ticket with `safe_update` set to false will succeed.