### PR TITLE
[chore] Await a bit for ticket creation

### DIFF
--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -2771,15 +2771,15 @@ public class RealSmokeTest {
     Ticket ticket = instance.createTicket(newTestTicket());
     try {
       assertThat(ticket.getId(), notNullValue());
-
-      Optional<Ticket> maybeTicket =
-          StreamSupport.stream(instance.getView(UNRESOLVED_TICKETS_VIEW_ID).spliterator(), false)
-              .filter(t -> Objects.equals(t.getId(), ticket.getId()))
-              .findFirst();
-      assertTrue(maybeTicket.isPresent());
+      await().until(() -> lookForTicket(ticket));
     } finally {
       instance.deleteTicket(ticket.getId());
     }
+  }
+
+  private boolean lookForTicket(Ticket ticket) {
+    return StreamSupport.stream(instance.getView(UNRESOLVED_TICKETS_VIEW_ID).spliterator(), false)
+        .anyMatch(t -> Objects.equals(t.getId(), ticket.getId()));
   }
 
   @Test


### PR DESCRIPTION
The `getUnresolvedViewReturnsANewlyCreatedTicket` started failing for no apparent reason.
It appears there is slight delay between the ticket creation and its appearance in the All tickets view. There is no real explanation for that, could be a setting change in our test instance, or a change Zendesk side.