### PR TITLE
[feature] Add support for user profiles API

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1346,28 +1346,94 @@ public class Zendesk implements Closeable {
             handleStatus()));
   }
 
-  public UserProfile createUserProfile(UserProfile userProfile) {
-    String idQuery = String.format(
+  public List<UserProfile> getUserProfilesForUser(User user) {
+    return getUserProfilesForUser(user.getId());
+  }
+
+  public List<UserProfile> getUserProfilesForUser(long userId) {
+    return complete(
+        submit(
+            req(
+                "GET",
+                tmpl("/users/{user_id}/profiles")
+                    .set("user_id", userId)),
+            handleList(UserProfile.class, "profiles")));
+  }
+
+  public UserProfile getUserProfile(UserProfile userProfile) {
+    return getUserProfile(userProfile.getId());
+  }
+
+  public UserProfile getUserProfile(String userProfileId) {
+    return complete(
+        submit(
+            req(
+                "GET",
+                tmpl("/user_profiles/{profile_id}")
+                    .set("profile_id", userProfileId)),
+            handle(UserProfile.class, "profile")));
+  }
+
+  public UserProfile getUserProfilebyIdentifier(String identifier) {
+    return complete(
+        submit(
+            req(
+                "GET",
+                tmpl("/user_profiles?identifier={identifier}")
+                    .set("identifier", identifier)),
+            handle(UserProfile.class, "profile")));
+  }
+
+  public UserProfile createOrUpdateUserProfile(UserProfile userProfile) {
+    return createOrUpdateUserProfile(userProfile,
+                                     userProfile.getIdentifiers().get(0).getType(),
+                                     userProfile.getIdentifiers().get(0).getValue());
+  }
+
+  public UserProfile createOrUpdateUserProfile(UserProfile userProfile, String identifierType, String identifierValue) {
+    String identifier = String.format(
         "%s:%s:%s:%s",
         userProfile.getSource(),
         userProfile.getType(),
-        userProfile.getIdentifiers().get(0).getType(),
-        userProfile.getIdentifiers().get(0).getValue());
+        identifierType,
+        identifierValue);
 
     return complete(
         submit(
             req(
                 "PUT",
-                tmpl("/user_profiles?identifier={idQuery}")
-                    .set("idQuery", idQuery),
+                tmpl("/user_profiles?identifier={identifier}")
+                    .set("identifier", identifier),
                 JSON,
                 json(Collections.singletonMap("profile", userProfile))),
             handle(UserProfile.class, "profile")));
   }
 
-  public List<UserProfile> getUserProfilesForUser(User user) {
+  public UserProfile updateUserProfile(UserProfile userProfile) {
+
     return complete(
-        submit(req("GET", tmpl("/users/{user_id}/profiles").set("user_id", user.getId())), handleList(UserProfile.class, "profiles")));
+        submit(
+            req(
+                "PUT",
+                tmpl("/user_profiles/{profile_id}")
+                    .set("profile_id", userProfile.getId()),
+                JSON,
+                json(Collections.singletonMap("profile", userProfile))),
+            handle(UserProfile.class, "profile")));
+  }
+
+  public void deleteUserProfile(UserProfile userProfile) {
+    deleteUserProfile(userProfile.getId());
+  }
+
+  public void deleteUserProfile(String userProfileId) {
+    complete(
+        submit(
+            req(
+                "DELETE",
+                tmpl("/user_profiles/{profile_id}")
+                    .set("profile_id", userProfileId)),
+            handleStatus()));
   }
 
   public List<Identity> getUserIdentities(User user) {

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -8,6 +8,26 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.asynchttpclient.AsyncCompletionHandler;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
@@ -84,27 +104,6 @@ import org.zendesk.client.v2.model.targets.PivotalTarget;
 import org.zendesk.client.v2.model.targets.Target;
 import org.zendesk.client.v2.model.targets.TwitterTarget;
 import org.zendesk.client.v2.model.targets.UrlTarget;
-
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * @author stephenc
@@ -1353,10 +1352,7 @@ public class Zendesk implements Closeable {
   public List<UserProfile> getUserProfilesForUser(long userId) {
     return complete(
         submit(
-            req(
-                "GET",
-                tmpl("/users/{user_id}/profiles")
-                    .set("user_id", userId)),
+            req("GET", tmpl("/users/{user_id}/profiles").set("user_id", userId)),
             handleList(UserProfile.class, "profiles")));
   }
 
@@ -1367,10 +1363,7 @@ public class Zendesk implements Closeable {
   public UserProfile getUserProfile(String userProfileId) {
     return complete(
         submit(
-            req(
-                "GET",
-                tmpl("/user_profiles/{profile_id}")
-                    .set("profile_id", userProfileId)),
+            req("GET", tmpl("/user_profiles/{profile_id}").set("profile_id", userProfileId)),
             handle(UserProfile.class, "profile")));
   }
 
@@ -1379,31 +1372,29 @@ public class Zendesk implements Closeable {
         submit(
             req(
                 "GET",
-                tmpl("/user_profiles?identifier={identifier}")
-                    .set("identifier", identifier)),
+                tmpl("/user_profiles?identifier={identifier}").set("identifier", identifier)),
             handle(UserProfile.class, "profile")));
   }
 
   public UserProfile createOrUpdateUserProfile(UserProfile userProfile) {
-    return createOrUpdateUserProfile(userProfile,
-                                     userProfile.getIdentifiers().get(0).getType(),
-                                     userProfile.getIdentifiers().get(0).getValue());
+    return createOrUpdateUserProfile(
+        userProfile,
+        userProfile.getIdentifiers().get(0).getType(),
+        userProfile.getIdentifiers().get(0).getValue());
   }
 
-  public UserProfile createOrUpdateUserProfile(UserProfile userProfile, String identifierType, String identifierValue) {
-    String identifier = String.format(
-        "%s:%s:%s:%s",
-        userProfile.getSource(),
-        userProfile.getType(),
-        identifierType,
-        identifierValue);
+  public UserProfile createOrUpdateUserProfile(
+      UserProfile userProfile, String identifierType, String identifierValue) {
+    String identifier =
+        String.format(
+            "%s:%s:%s:%s",
+            userProfile.getSource(), userProfile.getType(), identifierType, identifierValue);
 
     return complete(
         submit(
             req(
                 "PUT",
-                tmpl("/user_profiles?identifier={identifier}")
-                    .set("identifier", identifier),
+                tmpl("/user_profiles?identifier={identifier}").set("identifier", identifier),
                 JSON,
                 json(Collections.singletonMap("profile", userProfile))),
             handle(UserProfile.class, "profile")));
@@ -1415,8 +1406,7 @@ public class Zendesk implements Closeable {
         submit(
             req(
                 "PUT",
-                tmpl("/user_profiles/{profile_id}")
-                    .set("profile_id", userProfile.getId()),
+                tmpl("/user_profiles/{profile_id}").set("profile_id", userProfile.getId()),
                 JSON,
                 json(Collections.singletonMap("profile", userProfile))),
             handle(UserProfile.class, "profile")));
@@ -1429,10 +1419,7 @@ public class Zendesk implements Closeable {
   public void deleteUserProfile(String userProfileId) {
     complete(
         submit(
-            req(
-                "DELETE",
-                tmpl("/user_profiles/{profile_id}")
-                    .set("profile_id", userProfileId)),
+            req("DELETE", tmpl("/user_profiles/{profile_id}").set("profile_id", userProfileId)),
             handleStatus()));
   }
 

--- a/src/main/java/org/zendesk/client/v2/model/UserProfile.java
+++ b/src/main/java/org/zendesk/client/v2/model/UserProfile.java
@@ -1,0 +1,183 @@
+package org.zendesk.client.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class UserProfile implements SearchResultEntity, Serializable {
+
+    private Map<String, Object> attributes;
+    private Date createdAt;
+    private String id;
+    private List<Identifier> identifiers;
+    private String name;
+    private String source;
+    private String type;
+    private Date updatedAt;
+    private String userId;
+
+    public UserProfile(
+        Map<String, Object> attributes,
+        Date createdAt,
+        String id,
+        List<Identifier> identifiers,
+        String name,
+        String source,
+        String type,
+        Date updatedAt,
+        String userId) {
+
+        this.attributes = attributes;
+        this.createdAt = createdAt;
+        this.id = id;
+        this.identifiers = identifiers;
+        this.name = name;
+        this.source = source;
+        this.type = type;
+        this.updatedAt = updatedAt;
+        this.userId = userId;
+    }
+
+    public UserProfile() {}
+
+    public static class Identifier {
+
+        private String type;
+        private String value;
+
+        public Identifier() {
+        }
+
+        public Identifier(String type, String value) {
+
+            this.type = type;
+            this.value = value;
+        }
+
+        public String getType() {
+
+            return type;
+        }
+
+        public String getValue() {
+
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Identifier that = (Identifier) o;
+            return Objects.equals(type, that.type) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+
+            return Objects.hash(type, value);
+        }
+
+        @Override
+        public String toString() {
+
+            return "Identifier{" +
+                "type='" + type + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+        }
+    }
+
+    public Map<String, Object> getAttributes() {
+
+        return attributes;
+    }
+
+
+    @JsonProperty("created_at")
+    public Date getCreatedAt() {
+
+        return createdAt;
+    }
+
+    public String getId() {
+
+        return id;
+    }
+
+    public List<Identifier> getIdentifiers() {
+
+        return identifiers;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public String getSource() {
+
+        return source;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+
+    @JsonProperty("updated_at")
+    public Date getUpdatedAt() {
+
+        return updatedAt;
+    }
+
+    @JsonProperty("user_id")
+    public String getUserId() {
+
+        return userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserProfile that = (UserProfile) o;
+        return Objects.equals(attributes, that.attributes) && Objects.equals(createdAt, that.createdAt) && Objects.equals(id, that.id) && Objects.equals(identifiers, that.identifiers) && Objects.equals(name, that.name) && Objects.equals(source, that.source) && Objects.equals(type, that.type) && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(attributes, createdAt, id, identifiers, name, source, type, updatedAt, userId);
+    }
+
+    @Override
+    public String toString() {
+
+        return "UserProfile{" +
+            "attributes=" + attributes +
+            ", created_at=" + createdAt +
+            ", id='" + id + '\'' +
+            ", identifiers=" + identifiers +
+            ", name='" + name + '\'' +
+            ", source='" + source + '\'' +
+            ", type='" + type + '\'' +
+            ", updated_at=" + updatedAt +
+            ", user_id='" + userId + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/org/zendesk/client/v2/model/UserProfile.java
+++ b/src/main/java/org/zendesk/client/v2/model/UserProfile.java
@@ -1,8 +1,8 @@
 package org.zendesk.client.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -10,174 +10,262 @@ import java.util.Objects;
 
 public class UserProfile implements SearchResultEntity, Serializable {
 
-    private Map<String, Object> attributes;
-    private Date createdAt;
-    private String id;
-    private List<Identifier> identifiers;
-    private String name;
-    private String source;
+  private Map<String, Object> attributes;
+  private Date createdAt;
+  private String id;
+  private List<Identifier> identifiers;
+  private String name;
+  private String source;
+  private String type;
+  private Date updatedAt;
+  private String userId;
+
+  public UserProfile(
+      Map<String, Object> attributes,
+      List<Identifier> identifiers,
+      String name,
+      String source,
+      String type) {
+    this(
+        attributes,
+        Date.from(Instant.now()),
+        null,
+        identifiers,
+        name,
+        source,
+        type,
+        Date.from(Instant.now()),
+        null);
+  }
+
+  public UserProfile(
+      Map<String, Object> attributes,
+      List<Identifier> identifiers,
+      String name,
+      String source,
+      String type,
+      String userId) {
+    this(
+        attributes,
+        Date.from(Instant.now()),
+        null,
+        identifiers,
+        name,
+        source,
+        type,
+        Date.from(Instant.now()),
+        userId);
+  }
+
+  public UserProfile(
+      Map<String, Object> attributes,
+      Date createdAt,
+      String id,
+      List<Identifier> identifiers,
+      String name,
+      String source,
+      String type,
+      Date updatedAt,
+      String userId) {
+
+    this.attributes = attributes;
+    this.createdAt = createdAt;
+    this.id = id;
+    this.identifiers = identifiers;
+    this.name = name;
+    this.source = source;
+    this.type = type;
+    this.updatedAt = updatedAt;
+    this.userId = userId;
+  }
+
+  public UserProfile() {}
+
+  public static class Identifier {
+
     private String type;
-    private Date updatedAt;
-    private String userId;
+    private String value;
 
-    public UserProfile(
-        Map<String, Object> attributes,
-        Date createdAt,
-        String id,
-        List<Identifier> identifiers,
-        String name,
-        String source,
-        String type,
-        Date updatedAt,
-        String userId) {
+    public Identifier() {}
 
-        this.attributes = attributes;
-        this.createdAt = createdAt;
-        this.id = id;
-        this.identifiers = identifiers;
-        this.name = name;
-        this.source = source;
-        this.type = type;
-        this.updatedAt = updatedAt;
-        this.userId = userId;
-    }
+    public Identifier(String type, String value) {
 
-    public UserProfile() {}
-
-    public static class Identifier {
-
-        private String type;
-        private String value;
-
-        public Identifier() {
-        }
-
-        public Identifier(String type, String value) {
-
-            this.type = type;
-            this.value = value;
-        }
-
-        public String getType() {
-
-            return type;
-        }
-
-        public String getValue() {
-
-            return value;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Identifier that = (Identifier) o;
-            return Objects.equals(type, that.type) && Objects.equals(value, that.value);
-        }
-
-        @Override
-        public int hashCode() {
-
-            return Objects.hash(type, value);
-        }
-
-        @Override
-        public String toString() {
-
-            return "Identifier{" +
-                "type='" + type + '\'' +
-                ", value='" + value + '\'' +
-                '}';
-        }
-    }
-
-    public Map<String, Object> getAttributes() {
-
-        return attributes;
-    }
-
-
-    @JsonProperty("created_at")
-    public Date getCreatedAt() {
-
-        return createdAt;
-    }
-
-    public String getId() {
-
-        return id;
-    }
-
-    public List<Identifier> getIdentifiers() {
-
-        return identifiers;
-    }
-
-    public String getName() {
-
-        return name;
-    }
-
-    public String getSource() {
-
-        return source;
+      this.type = type;
+      this.value = value;
     }
 
     public String getType() {
 
-        return type;
+      return type;
     }
 
-    @JsonProperty("updated_at")
-    public Date getUpdatedAt() {
+    public String getValue() {
 
-        return updatedAt;
-    }
-
-    @JsonProperty("user_id")
-    public String getUserId() {
-
-        return userId;
+      return value;
     }
 
     @Override
     public boolean equals(Object o) {
 
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        UserProfile that = (UserProfile) o;
-        return Objects.equals(attributes, that.attributes) && Objects.equals(createdAt, that.createdAt) && Objects.equals(id, that.id) && Objects.equals(identifiers, that.identifiers) && Objects.equals(name, that.name) && Objects.equals(source, that.source) && Objects.equals(type, that.type) && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(userId, that.userId);
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Identifier that = (Identifier) o;
+      return Objects.equals(type, that.type) && Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(attributes, createdAt, id, identifiers, name, source, type, updatedAt, userId);
+      return Objects.hash(type, value);
     }
 
     @Override
     public String toString() {
 
-        return "UserProfile{" +
-            "attributes=" + attributes +
-            ", created_at=" + createdAt +
-            ", id='" + id + '\'' +
-            ", identifiers=" + identifiers +
-            ", name='" + name + '\'' +
-            ", source='" + source + '\'' +
-            ", type='" + type + '\'' +
-            ", updated_at=" + updatedAt +
-            ", user_id='" + userId + '\'' +
-            '}';
+      return "Identifier{" + "type='" + type + '\'' + ", value='" + value + '\'' + '}';
     }
+  }
+
+  public Map<String, Object> getAttributes() {
+
+    return attributes;
+  }
+
+  @JsonProperty("created_at")
+  public Date getCreatedAt() {
+
+    return createdAt;
+  }
+
+  public String getId() {
+
+    return id;
+  }
+
+  public List<Identifier> getIdentifiers() {
+
+    return identifiers;
+  }
+
+  public String getName() {
+
+    return name;
+  }
+
+  public String getSource() {
+
+    return source;
+  }
+
+  public String getType() {
+
+    return type;
+  }
+
+  @JsonProperty("updated_at")
+  public Date getUpdatedAt() {
+
+    return updatedAt;
+  }
+
+  @JsonProperty("user_id")
+  public String getUserId() {
+
+    return userId;
+  }
+
+  public void addAttribute(String key, Object value) {
+    this.attributes.put(key, Objects.requireNonNull(value));
+  }
+
+  public void setAttributes(Map<String, Object> attributes) {
+
+    this.attributes = attributes;
+  }
+
+  public void addIdentifier(Identifier identifier) {
+    this.identifiers.add(identifier);
+  }
+
+  public void setIdentifiers(List<Identifier> identifiers) {
+
+    this.identifiers = identifiers;
+  }
+
+  public void setName(String name) {
+
+    this.name = name;
+  }
+
+  public void setType(String type) {
+
+    this.type = type;
+  }
+
+  public void setSource(String source) {
+
+    this.source = source;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UserProfile that = (UserProfile) o;
+    return Objects.equals(attributes, that.attributes)
+        && Objects.equals(createdAt, that.createdAt)
+        && Objects.equals(id, that.id)
+        && Objects.equals(identifiers, that.identifiers)
+        && Objects.equals(name, that.name)
+        && Objects.equals(source, that.source)
+        && Objects.equals(type, that.type)
+        && Objects.equals(updatedAt, that.updatedAt)
+        && Objects.equals(userId, that.userId);
+  }
+
+  @Override
+  public int hashCode() {
+
+    return Objects.hash(
+        attributes, createdAt, id, identifiers, name, source, type, updatedAt, userId);
+  }
+
+  @Override
+  public String toString() {
+
+    return "UserProfile{"
+        + "attributes="
+        + attributes
+        + ", created_at="
+        + createdAt
+        + ", id='"
+        + id
+        + '\''
+        + ", identifiers="
+        + identifiers
+        + ", name='"
+        + name
+        + '\''
+        + ", source='"
+        + source
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", updated_at="
+        + updatedAt
+        + ", user_id='"
+        + userId
+        + '\''
+        + '}';
+  }
 }

--- a/src/test/java/org/zendesk/client/v2/model/UserProfileTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/UserProfileTest.java
@@ -1,0 +1,48 @@
+package org.zendesk.client.v2.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.zendesk.client.v2.Zendesk;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserProfileTest {
+
+    public static final Long USER_ID = 123L;
+    public static final String PROFILE_NAME = "name";
+
+    @Test
+    public void serializeDeserialize() throws JsonProcessingException {
+        ObjectMapper mapper = Zendesk.createMapper();
+        String email = "user123@example.com";
+        UserProfile profile = createSampleUserProfile(email);
+        String serialized = mapper.writeValueAsString(profile);
+
+        UserProfile deserialized = mapper.readValue(serialized, UserProfile.class);
+        assertThat(deserialized.getName()).isEqualTo(PROFILE_NAME);
+        assertThat(deserialized.getUserId()).isEqualTo("123");
+        assertThat(deserialized.getIdentifiers()).contains(new UserProfile.Identifier("email", email));
+    }
+
+    private UserProfile createSampleUserProfile(String email) {
+        var identifiers = List.of(new UserProfile.Identifier("email", email));
+
+        return new UserProfile(
+            Map.of("customer_ref", "ref123"),
+            Date.from(Instant.now()),
+            "12345",
+            identifiers,
+            PROFILE_NAME,
+            "source",
+            "type",
+            Date.from(Instant.now()),
+            USER_ID.toString()
+        );
+    }
+}

--- a/src/test/java/org/zendesk/client/v2/model/UserProfileTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/UserProfileTest.java
@@ -1,48 +1,49 @@
 package org.zendesk.client.v2.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.zendesk.client.v2.Zendesk;
-
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.zendesk.client.v2.Zendesk;
 
 public class UserProfileTest {
 
-    public static final Long USER_ID = 123L;
-    public static final String PROFILE_NAME = "name";
+  public static final String USER_ID = "123";
+  public static final String PROFILE_NAME = "name";
+  public static final String EMAIL = "user123@example.com";
 
-    @Test
-    public void serializeDeserialize() throws JsonProcessingException {
-        ObjectMapper mapper = Zendesk.createMapper();
-        String email = "user123@example.com";
-        UserProfile profile = createSampleUserProfile(email);
-        String serialized = mapper.writeValueAsString(profile);
+  @Test
+  public void serializeDeserialize() throws JsonProcessingException {
+    ObjectMapper mapper = Zendesk.createMapper();
+    UserProfile profile = createSampleUserProfile();
+    String serialized = mapper.writeValueAsString(profile);
 
-        UserProfile deserialized = mapper.readValue(serialized, UserProfile.class);
-        assertThat(deserialized.getName()).isEqualTo(PROFILE_NAME);
-        assertThat(deserialized.getUserId()).isEqualTo("123");
-        assertThat(deserialized.getIdentifiers()).contains(new UserProfile.Identifier("email", email));
-    }
+    UserProfile deserialized = mapper.readValue(serialized, UserProfile.class);
+    assertThat(deserialized.getName()).isEqualTo(PROFILE_NAME);
+    assertThat(deserialized.getUserId()).isEqualTo(USER_ID);
+    assertThat(deserialized.getIdentifiers())
+        .first()
+        .extracting(UserProfile.Identifier::getType, UserProfile.Identifier::getValue)
+        .contains("email", EMAIL);
+  }
 
-    private UserProfile createSampleUserProfile(String email) {
-        var identifiers = List.of(new UserProfile.Identifier("email", email));
+  private UserProfile createSampleUserProfile() {
+    var identifiers = List.of(new UserProfile.Identifier("email", EMAIL));
 
-        return new UserProfile(
-            Map.of("customer_ref", "ref123"),
-            Date.from(Instant.now()),
-            "12345",
-            identifiers,
-            PROFILE_NAME,
-            "source",
-            "type",
-            Date.from(Instant.now()),
-            USER_ID.toString()
-        );
-    }
+    return new UserProfile(
+        Map.of("customer_ref", "ref123"),
+        Date.from(Instant.now()),
+        "12345",
+        identifiers,
+        PROFILE_NAME,
+        "source",
+        "type",
+        Date.from(Instant.now()),
+        USER_ID);
+  }
 }


### PR DESCRIPTION
Adds support for the following User Profile CRUD operations (documented [here](https://developer.zendesk.com/api-reference/ticketing/users/profiles_api/profiles_api/#create-or-update-profile-by-user-id))

```
GET /api/v2/users/{user_id}/profiles
GET /api/v2/user_profiles/{profile_id}
GET /api/v2/user_profiles?identifier={identifier}
PUT /api/v2/users/{user_id}/profiles?identifier={identifier}
PUT /api/v2/user_profiles?identifier={identifier}
PUT /api/v2/user_profiles/{profile_id}
DELETE /api/v2/user_profiles/{profile_id}
```

